### PR TITLE
Added object and test suite for Mercurial plug-in

### DIFF
--- a/doorstop/core/vcs/__init__.py
+++ b/doorstop/core/vcs/__init__.py
@@ -5,13 +5,14 @@ import logging
 
 from doorstop import common
 from doorstop.common import DoorstopError
-from doorstop.core.vcs import git, subversion, veracity, mockvcs
+from doorstop.core.vcs import git, subversion, veracity, mockvcs, mercurial
 
 DEFAULT = mockvcs.WorkingCopy
 DIRECTORIES = {
     git.WorkingCopy.DIRECTORY: git.WorkingCopy,
     subversion.WorkingCopy.DIRECTORY: subversion.WorkingCopy,
     veracity.WorkingCopy.DIRECTORY: veracity.WorkingCopy,
+    mercurial.WorkingCopy.DIRECTORY: mercurial.WorkingCopy,
     DEFAULT.DIRECTORY: DEFAULT,
 }
 

--- a/doorstop/core/vcs/mercurial.py
+++ b/doorstop/core/vcs/mercurial.py
@@ -1,0 +1,32 @@
+"""Plug-in module to store requirements in a Mercurial repository."""
+
+from doorstop import common
+from doorstop.core.vcs.base import BaseWorkingCopy
+
+log = common.logger(__name__)
+
+
+class WorkingCopy(BaseWorkingCopy):
+
+    """Mercurial working copy."""
+
+    DIRECTORY = '.hg'
+    IGNORES = ('.hgignore',)
+
+    def lock(self, path):
+        log.debug("`hg` does not support locking: {}".format(path))
+        self.call('hg', 'pull', '-u')
+
+    def edit(self, path):
+        self.call('hg', 'add', path)
+
+    def add(self, path):
+        self.call('hg', 'add', path)
+
+    def delete(self, path):
+        self.call('hg', 'remove', path, '--force')
+
+    def commit(self, message=None):
+        message = message or input("Commit message: ")  # pylint: disable=W0141
+        self.call('hg', 'commit', '--message', message)
+        self.call('hg', 'push')

--- a/doorstop/core/vcs/test/test_commands.py
+++ b/doorstop/core/vcs/test/test_commands.py
@@ -195,3 +195,42 @@ class TestVeracity(BaseTestCase):
         calls = [call(("vv", "commit", "--message", self.message)),
                  call(("vv", "push"))]
         mock_call.assert_has_calls(calls)
+
+
+@patch('subprocess.call')  # pylint: disable=R0904
+class TestMercurial(BaseTestCase):
+
+    """Tests for the Mercurial plugin."""
+
+    DIRECTORY = '.hg'
+
+    def test_lock(self, mock_call):
+        """Verify Mercurial can (fake) lock files."""
+        self.lock()
+        calls = [call(("hg", "pull", "-u"))]
+        mock_call.assert_has_calls(calls)
+
+    def test_edit(self, mock_call):
+        """Verify Mercurial can edit files."""
+        self.edit()
+        calls = [call(("hg", "add", self.path))]
+        mock_call.assert_has_calls(calls)
+
+    def test_add(self, mock_call):
+        """Verify Mercurial can add files."""
+        self.add()
+        calls = [call(("hg", "add", self.path))]
+        mock_call.assert_has_calls(calls)
+
+    def test_delete(self, mock_call):
+        """Verify Mercurial can delete files."""
+        self.delete()
+        calls = [call(("hg", "remove", self.path, "--force"))]
+        mock_call.assert_has_calls(calls)
+
+    def test_commit(self, mock_call):
+        """Verify Mercurial can commit files."""
+        self.commit()
+        calls = [call(("hg", "commit", "--message", self.message)),
+                 call(("hg", "push"))]
+        mock_call.assert_has_calls(calls)


### PR DESCRIPTION
Though not as widespread as Git, as a distributed version control system, Mercurial is becoming quite popular. A relatively similar command-line interface to Git makes adding a plug-in to Doorstop quite simple, but eases use for developers who prefer Mercurial.