### PR TITLE
Report the item id that generated the exception

### DIFF
--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -193,7 +193,11 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
                 else:
                     self._items.append(item)
                     if reload:
-                        item.load(reload=reload)
+                        try:
+                            item.load(reload=reload)
+                        except Exception as e:
+                            print("!! Exception loading %s" % item)
+                            raise e
                     if settings.CACHE_ITEMS and self.tree:
                         self.tree._item_cache[item.uid] = item  # pylint: disable=W0212
                         log.trace("cached item: {}".format(item))

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -195,9 +195,9 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
                     if reload:
                         try:
                             item.load(reload=reload)
-                        except Exception as e:
-                            print("!! Exception loading %s" % item)
-                            raise e
+                        except Exception:
+                            log.error("Unable to load: %s", item)
+                            raise
                     if settings.CACHE_ITEMS and self.tree:
                         self.tree._item_cache[item.uid] = item  # pylint: disable=W0212
                         log.trace("cached item: {}".format(item))


### PR DESCRIPTION
If the yaml file of an item is edited directly then it can cause an exception when later doorstop commands are run, e.g. publish. This change displays the UID of the item that caused the exception making it easier to fix.