### PR TITLE
Support the use of markdwn tables in the text descriptions

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -294,7 +294,7 @@ def _lines_markdown(obj, linkify=False):
             # Text
             if item.text:
                 yield ""  # break before text
-                yield from item.text.splitlines()
+                yield item.text
 
             # Reference
             if item.ref:
@@ -428,7 +428,7 @@ def _lines_html(obj, linkify=False, charset='UTF-8'):
         yield '</head>'
         yield '<body>'
     text = '\n'.join(_lines_markdown(obj, linkify=linkify))
-    html = markdown.markdown(text, extensions=['extra', 'nl2br', 'sane_lists'])
+    html = markdown.markdown(text, extensions=['extra', 'sane_lists', 'tables'])
     yield from html.splitlines()
     if document:
         yield '</body>'

--- a/doorstop/core/types.py
+++ b/doorstop/core/types.py
@@ -266,7 +266,7 @@ class Text(str):
         'list:\n\n- a\n- b\n'
 
         """
-        return Text
+        return value
 
     @staticmethod
     def save_text(text, end='\n'):

--- a/doorstop/core/types.py
+++ b/doorstop/core/types.py
@@ -260,13 +260,13 @@ class Text(str):
         r"""Convert dumped text to the original string.
 
         >>> Text.load_text("abc\ndef")
-        'abc def'
+        'abc\ndef'
 
         >>> Text.load_text("list:\n\n- a\n- b\n")
-        'list:\n\n- a\n- b'
+        'list:\n\n- a\n- b\n'
 
         """
-        return Text.join(value if value else "")
+        return Text
 
     @staticmethod
     def save_text(text, end='\n'):
@@ -351,21 +351,6 @@ class Text(str):
     ([^\n])  # any character but a newline
     """, re.VERBOSE | re.IGNORECASE)
 
-    @staticmethod
-    def join(text):
-        r"""Convert single newlines (ignored by Markdown) to spaces.
-
-        >>> Text.join("abc\n123")
-        'abc 123'
-
-        >>> Text.join("abc\n\n123")
-        'abc\n\n123'
-
-        >>> Text.join("abc \n123")
-        'abc 123'
-
-        """
-        return Text.RE_MARKDOWN_SPACES.sub(r'\1 \3', text).strip()
 
 
 class Level(object):


### PR DESCRIPTION
I've made these changes so that I can use markdown tables in text field. I don't think the code currently support any multi line features. I expect I should add some tests before this could get merged.

Tables can be formatted like this.

| Headin1 | Heading2 |
| --- | --- |
| Row 1 | some number |
