### PR TITLE
Add option to omit levels from all items or only non heading items

### DIFF
--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -295,7 +295,7 @@ def _publish(subs, shared):
                      help="limit line width on text output")
     sub.add_argument('-C', '--no-child-links', action='store_true',
                      help="do not include child links on items")
-    sub.add_argument('-L', dest='no_body_levels', action='store_true',
+    sub.add_argument('-L', '--no-body-levels', dest='no_body_levels', action='store_true',
                      default=False,
                      help="do not include levels on non-heading items")
     sub.add_argument('--no-levels', choices=['all', 'body'],

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -295,8 +295,11 @@ def _publish(subs, shared):
                      help="limit line width on text output")
     sub.add_argument('-C', '--no-child-links', action='store_true',
                      help="do not include child links on items")
-    sub.add_argument('-L', '--no-body-levels', action='store_true',
+    sub.add_argument('-L', dest='no_body_levels', action='store_true',
+                     default=False,
                      help="do not include levels on non-heading items")
+    sub.add_argument('--no-levels', choices=['all', 'body'],
+                     help="do not include levels on heading and non-heading or non-heading items")
 
 
 if __name__ == '__main__':  # pragma: no cover (manual test)

--- a/doorstop/cli/test/test_all.py
+++ b/doorstop/cli/test/test_all.py
@@ -699,11 +699,16 @@ class TestPublish(TempTestCase):
 
     def test_publish_document_without_body_levels(self):
         """Verify 'doorstop publish' can create output without body levels."""
+        self.assertIs(None, main(['publish', 'tut', '--no-body-levels']))
+        self.assertFalse(settings.PUBLISH_BODY_LEVELS)
+
+    def test_publish_document_no_body_levels(self):
+        """Verify 'doorstop publish' can create output without body levels."""
         self.assertIs(None, main(['publish', 'tut', '--no-levels=body']))
         self.assertFalse(settings.PUBLISH_BODY_LEVELS)
 
-    def test_publish_document_without_heading_levels(self):
-        """Verify 'doorstop publish' can create output without heading levels."""
+    def test_publish_document_no_body_or_heading_levels(self):
+        """Verify 'doorstop publish' can create output without heading or body levels."""
         self.assertIs(None, main(['publish', 'tut', '--no-levels=all']))
         self.assertFalse(settings.PUBLISH_BODY_LEVELS)
         self.assertFalse(settings.PUBLISH_HEADING_LEVELS)

--- a/doorstop/cli/test/test_all.py
+++ b/doorstop/cli/test/test_all.py
@@ -699,8 +699,14 @@ class TestPublish(TempTestCase):
 
     def test_publish_document_without_body_levels(self):
         """Verify 'doorstop publish' can create output without body levels."""
-        self.assertIs(None, main(['publish', 'tut', '--no-body-levels']))
+        self.assertIs(None, main(['publish', 'tut', '--no-levels=body']))
         self.assertFalse(settings.PUBLISH_BODY_LEVELS)
+
+    def test_publish_document_without_heading_levels(self):
+        """Verify 'doorstop publish' can create output without heading levels."""
+        self.assertIs(None, main(['publish', 'tut', '--no-levels=all']))
+        self.assertFalse(settings.PUBLISH_BODY_LEVELS)
+        self.assertFalse(settings.PUBLISH_HEADING_LEVELS)
 
     def test_publish_document_error_empty(self):
         """Verify 'doorstop publish' returns an error in an empty folder."""

--- a/doorstop/cli/utilities.py
+++ b/doorstop/cli/utilities.py
@@ -4,6 +4,7 @@ import os
 import ast
 from argparse import ArgumentTypeError
 import logging
+import warnings
 
 from doorstop import common
 from doorstop import settings
@@ -114,6 +115,8 @@ def configure_settings(args):
         settings.PUBLISH_CHILD_LINKS = args.no_child_links is False
     if hasattr(args, 'no_body_levels'):
         settings.PUBLISH_BODY_LEVELS = not args.no_body_levels
+        msg = "'--no-body-levels' option will be removed in a future release"
+        warnings.warn(msg, DeprecationWarning)
     if hasattr(args, 'no_levels') and args.no_levels is not None:
         settings.PUBLISH_BODY_LEVELS = False
         settings.PUBLISH_HEADING_LEVELS = args.no_levels != 'all'

--- a/doorstop/cli/utilities.py
+++ b/doorstop/cli/utilities.py
@@ -112,8 +112,11 @@ def configure_settings(args):
     # Parse `publish` settings
     if hasattr(args, 'no_child_links') and args.no_child_links is not None:
         settings.PUBLISH_CHILD_LINKS = args.no_child_links is False
-    if hasattr(args, 'no_body_levels') and args.no_body_levels is not None:
-        settings.PUBLISH_BODY_LEVELS = args.no_body_levels is False
+    if hasattr(args, 'no_body_levels'):
+        settings.PUBLISH_BODY_LEVELS = not args.no_body_levels
+    if hasattr(args, 'no_levels') and args.no_levels is not None:
+        settings.PUBLISH_BODY_LEVELS = False
+        settings.PUBLISH_HEADING_LEVELS = args.no_levels != 'all'
 
 
 def literal_eval(literal, error=None, default=None):

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -216,7 +216,7 @@ def _lines_text(obj, indent=8, width=79, **_):
                 yield "{l:<{s}}{t}".format(l=level, s=indent, t=item.text)
             else:
                 yield "{t}".format(t=item.text)
-                
+
         else:
 
             # Level and UID

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -277,7 +277,10 @@ def _lines_markdown(obj, linkify=False):
         if item.heading:
 
             # Level and Text
-            standard = "{h} {l} {t}".format(h=heading, l=level, t=item.text)
+            if settings.PUBLISH_HEADING_LEVELS:
+                standard = "{h} {l} {t}".format(h=heading, l=level, t=item.text)
+            else:
+                standard = "{h} {t}".format(h=heading, t=item.text)
             attr_list = _format_md_attr_list(item, linkify)
             yield standard + attr_list
 

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -212,8 +212,11 @@ def _lines_text(obj, indent=8, width=79, **_):
         if item.heading:
 
             # Level and Text
-            yield "{l:<{s}}{t}".format(l=level, s=indent, t=item.text)
-
+            if settings.PUBLISH_HEADING_LEVELS:
+                yield "{l:<{s}}{t}".format(l=level, s=indent, t=item.text)
+            else:
+                yield "{t}".format(t=item.text)
+                
         else:
 
             # Level and UID

--- a/doorstop/core/test/test_publisher.py
+++ b/doorstop/core/test/test_publisher.py
@@ -152,6 +152,16 @@ class TestModule(MockDataMixIn, unittest.TestCase):
         # Assert
         self.assertEqual(expected, text)
 
+    @patch('doorstop.settings.PUBLISH_HEADING_LEVELS', False)
+    def test_lines_text_item_heading_no_heading_levels(self):
+        """Verify an item heading level can be ommitted."""
+        expected = "Heading\n\n"
+        lines = publisher.publish_lines(self.item, '.txt')
+        # Act
+        text = ''.join(line + '\n' for line in lines)
+        # Assert
+        self.assertEqual(expected, text)
+
     @patch('doorstop.settings.PUBLISH_CHILD_LINKS', False)
     def test_lines_text_item_normative(self):
         """Verify text can be published from an item (normative)."""
@@ -192,6 +202,16 @@ class TestModule(MockDataMixIn, unittest.TestCase):
     def test_lines_markdown_item_heading(self):
         """Verify Markdown can be published from an item (heading)."""
         expected = "## 1.1 Heading {: #req3 }\n\n"
+        # Act
+        lines = publisher.publish_lines(self.item, '.md', linkify=True)
+        text = ''.join(line + '\n' for line in lines)
+        # Assert
+        self.assertEqual(expected, text)
+
+    @patch('doorstop.settings.PUBLISH_HEADING_LEVELS', False)
+    def test_lines_markdown_item_heading_no_heading_levels(self):
+        """Verify an item heading level can be ommitted."""
+        expected = "## Heading {: #req3 }\n\n"
         # Act
         lines = publisher.publish_lines(self.item, '.md', linkify=True)
         text = ''.join(line + '\n' for line in lines)
@@ -253,6 +273,16 @@ class TestModule(MockDataMixIn, unittest.TestCase):
     def test_lines_html_item(self):
         """Verify HTML can be published from an item."""
         expected = '<h2>1.1 Heading</h2>\n'
+        # Act
+        lines = publisher.publish_lines(self.item, '.html')
+        text = ''.join(line + '\n' for line in lines)
+        # Assert
+        self.assertEqual(expected, text)
+
+    @patch('doorstop.settings.PUBLISH_HEADING_LEVELS', False)
+    def test_lines_html_item_no_heading_levels(self):
+        """Verify an item heading level can be ommitted."""
+        expected = '<h2>Heading</h2>\n'
         # Act
         lines = publisher.publish_lines(self.item, '.html')
         text = ''.join(line + '\n' for line in lines)

--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -45,6 +45,7 @@ STAMP_NEW_LINKS = True  # automatically stamp links upon creation
 # Publishing settings
 PUBLISH_CHILD_LINKS = True  # include child links when publishing
 PUBLISH_BODY_LEVELS = True  # include levels on non-header items
+PUBLISH_HEADING_LEVELS = True  # include levels on header items
 
 # Version control settings
 ADDREMOVE_FILES = True  # automatically add/remove new/changed files


### PR DESCRIPTION
PR to close issue #211.

I left in the -L option but removed the --no-body-levels option so shouldn't break existing use too much.