### PR TITLE
 Remove trailing white space from every line of text

### DIFF
--- a/doorstop/core/test/test_item.py
+++ b/doorstop/core/test/test_item.py
@@ -276,7 +276,7 @@ class TestItem(unittest.TestCase):
     def test_text_non_heading(self):
         """Verify newlines are preserved around non-headings."""
         self.item.text = "break (before \n#2) symbol should not be a heading."
-        expected = "break (before \n#2) symbol should not be a heading."
+        expected = "break (before\n#2) symbol should not be a heading."
         self.assertEqual(expected, self.item.text)
 
     def test_text_heading(self):

--- a/doorstop/core/test/test_types.py
+++ b/doorstop/core/test/test_types.py
@@ -172,19 +172,19 @@ class TestText(unittest.TestCase):
 
     def test_repr(self):
         """Verify text can be represented."""
-        self.assertEqual("'Hello, \\nworld!'", repr(self.text))
+        self.assertEqual("'Hello,\\nworld!'", repr(self.text))
 
     def test_str(self):
         """Verify text can be converted to strings."""
-        self.assertEqual("Hello, \nworld!", str(self.text))
+        self.assertEqual("Hello,\nworld!", str(self.text))
 
     def test_eq(self):
         """Verify text can be equated."""
-        self.assertEqual(Text("Hello, \nworld!"), self.text)
+        self.assertEqual(Text("Hello,\nworld!"), self.text)
 
     def test_yaml(self):
         """Verify levels can be converted to their YAML representation."""
-        self.assertEqual('Hello, \nworld!\n', self.text.yaml)
+        self.assertEqual('Hello,\nworld!\n', self.text.yaml)
 
     def test_dump_yaml(self):
         """Verify levels can be converted to their YAML representation."""
@@ -196,6 +196,12 @@ class TestText(unittest.TestCase):
         with a hint as to the indent."""
         text = Text(' abc ')
         self.assertEqual('|2\n   abc\n', yaml.dump(text.yaml))
+
+    def test_dump_yaml_space_before_newline(self):
+        """Text starting with a space is encoded to a yaml literal string
+        with a hint as to the indent."""
+        text = Text('hello \nworld\n')
+        self.assertEqual('|\n  hello\n  world\n', yaml.dump(text.yaml))
 
 
 class TestLevel(unittest.TestCase):

--- a/doorstop/core/types.py
+++ b/doorstop/core/types.py
@@ -270,7 +270,8 @@ class Text(str):
             return ""
         text_value = re.sub('^\n+', '', value)
         text_value = re.sub('\n+$', '', text_value)
-        return text_value.rstrip(' ')
+        text_value = '\n'.join([s.rstrip() for s in text_value.split('\n')])
+        return text_value
 
     @staticmethod
     def save_text(text, end='\n'):


### PR DESCRIPTION
pyyaml stops saving text as literal if there is a trailing space before a new line. The code previously removed trailing white space from the last line, but now it removes trailing white space from every line.