### PR TITLE
The markdown module no longer converts newlines to breaks

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -95,7 +95,7 @@ def _index(directory, index=INDEX, extensions=('.html',), tree=None):
     if filenames:
         path = os.path.join(directory, index)
         log.info("creating an {}...".format(index))
-        lines = _lines_index(filenames, tree=tree)
+        lines = _lines_index(sorted(filenames), tree=tree)
         common.write_lines(lines, path)
     else:
         log.warning("no files for {}".format(index))

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -12,7 +12,6 @@ from doorstop import settings
 
 EXTENSIONS = [
     'markdown.extensions.extra',
-    'markdown.extensions.nl2br',
     'markdown.extensions.sane_lists',
 ]
 CSS = os.path.join(os.path.dirname(__file__), 'files', 'doorstop.css')

--- a/doorstop/core/test/files/published.html
+++ b/doorstop/core/test/files/published.html
@@ -126,13 +126,13 @@ tr.alt td {
 </head>
 <body>
 <h3 id="REQ001">1.2.3 REQ001</h3>
-<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod<br />
-tempor incididunt ut labore et dolore magna aliqua.<br />
-Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut<br />
-aliquip ex ea commodo consequat.<br />
-Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore<br />
-eu fugiat nulla pariatur.<br />
-Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia<br />
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.</p>
 <p><em>Parent links:</em> <a href="SYS.html#SYS001">SYS001</a>, <a href="SYS.html#SYS002">SYS002</a></p>
 <h2 id="REQ003">1.4 REQ003</h2>

--- a/doorstop/core/test/files/published2.html
+++ b/doorstop/core/test/files/published2.html
@@ -126,13 +126,13 @@ tr.alt td {
 </head>
 <body>
 <h3>1.2.3 REQ001</h3>
-<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod<br />
-tempor incididunt ut labore et dolore magna aliqua.<br />
-Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut<br />
-aliquip ex ea commodo consequat.<br />
-Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore<br />
-eu fugiat nulla pariatur.<br />
-Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia<br />
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.</p>
 <p><em>Links: SYS001, SYS002</em></p>
 <h2>1.4 REQ003</h2>


### PR DESCRIPTION
Removed the extension nl2br so that new lines are no longer converted to breaks, closes #217.