### PR TITLE
Parent links are now links in markdown documents

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -43,7 +43,7 @@ def publish(obj, path, ext=None, linkify=None, index=None, **kwargs):
     ext = ext or os.path.splitext(path)[-1] or '.html'
     check(ext)
     if linkify is None:
-        linkify = is_tree(obj) and ext == '.html'
+        linkify = is_tree(obj) and ext in ['.html', '.md']
     if index is None:
         index = is_tree(obj) and ext == '.html'
 
@@ -346,7 +346,7 @@ def _format_level(level):
 
 def _format_md_attr_list(item, linkify):
     """Create a Markdown attribute list for a heading."""
-    return " {{: #{u} }}".format(u=item.uid) if linkify else ''
+    return " {{#{u} }}".format(u=item.uid) if linkify else ''
 
 
 def _format_text_ref(item):

--- a/doorstop/core/test/test_publisher.py
+++ b/doorstop/core/test/test_publisher.py
@@ -201,7 +201,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
 
     def test_lines_markdown_item_heading(self):
         """Verify Markdown can be published from an item (heading)."""
-        expected = "## 1.1 Heading {: #req3 }\n\n"
+        expected = "## 1.1 Heading {#req3 }\n\n"
         # Act
         lines = publisher.publish_lines(self.item, '.md', linkify=True)
         text = ''.join(line + '\n' for line in lines)
@@ -211,7 +211,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
     @patch('doorstop.settings.PUBLISH_HEADING_LEVELS', False)
     def test_lines_markdown_item_heading_no_heading_levels(self):
         """Verify an item heading level can be ommitted."""
-        expected = "## Heading {: #req3 }\n\n"
+        expected = "## Heading {#req3 }\n\n"
         # Act
         lines = publisher.publish_lines(self.item, '.md', linkify=True)
         text = ''.join(line + '\n' for line in lines)


### PR DESCRIPTION
When publish all of the documents to markdown I think the parent links should be linkified, just as if we are publishing html.

If the markdown is later converted to html with pandoc then the links word correctly