### PR TITLE
Attributes are now added to the first line of a heading item

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -282,15 +282,15 @@ def _lines_markdown(obj, linkify=False):
         level = _format_level(item.level)
 
         if item.heading:
-
+            text_lines = item.text.splitlines()
             # Level and Text
             if settings.PUBLISH_HEADING_LEVELS:
-                standard = "{h} {l} {t}".format(h=heading, l=level, t=item.text)
+                standard = "{h} {l} {t}".format(h=heading, l=level, t=text_lines[0])
             else:
                 standard = "{h} {t}".format(h=heading, t=item.text)
             attr_list = _format_md_attr_list(item, linkify)
             yield standard + attr_list
-
+            yield from text_lines[1:]
         else:
 
             # Level and UID

--- a/doorstop/core/test/test_publisher.py
+++ b/doorstop/core/test/test_publisher.py
@@ -8,7 +8,7 @@ import os
 from doorstop.common import DoorstopError
 from doorstop.core import publisher
 
-from doorstop.core.test import FILES, EMPTY, MockDataMixIn
+from doorstop.core.test import FILES, EMPTY, MockDataMixIn, MockItemAndVCS
 
 
 class TestModule(MockDataMixIn, unittest.TestCase):
@@ -157,6 +157,29 @@ class TestModule(MockDataMixIn, unittest.TestCase):
         """Verify an item heading level can be ommitted."""
         expected = "Heading\n\n"
         lines = publisher.publish_lines(self.item, '.txt')
+        # Act
+        text = ''.join(line + '\n' for line in lines)
+        # Assert
+        self.assertEqual(expected, text)
+
+    def test_single_line_heading_to_markdown(self):
+        """A single line heading is published as a heading with an attribute equal to the item id"""
+        expected = "## 1.1 Heading {#req3 }\n\n"
+        lines = publisher.publish_lines(self.item, '.md', linkify=True)
+        # Act
+        text = ''.join(line + '\n' for line in lines)
+        # Assert
+        self.assertEqual(expected, text)
+
+    def test_multi_line_heading_to_markdown(self):
+        """A multi line heading is published as a heading with an attribute equal to the item id"""
+        item = MockItemAndVCS('path/to/req3.yml',
+                              _file=("links: [sys3]" + '\n'
+                                     "text: 'Heading\n\nThis section describes publishing.'" + '\n'
+                                     "level: 1.1.0" + '\n'
+                                     "normative: false"))
+        expected = "## 1.1 Heading {#req3 }\nThis section describes publishing.\n\n"
+        lines = publisher.publish_lines(item, '.md', linkify=True)
         # Act
         text = ''.join(line + '\n' for line in lines)
         # Assert


### PR DESCRIPTION
Even if heading has multiple lines the attribute is now correctly added to the end of the first line, which becomes the heading text. The remaining lines can be used for some descriptive introduction under the heading.