### PR TITLE
The contents of each assets directory is now copied to the publish location

### DIFF
--- a/doorstop/common.py
+++ b/doorstop/common.py
@@ -2,9 +2,9 @@
 
 import os
 import shutil
-from distutils import dir_util
 import argparse
 import logging
+import glob
 
 import yaml
 
@@ -180,13 +180,14 @@ def touch(path):  # pragma: no cover (integration test)
         write_text('', path)
 
 
-def copy(src, dst):
-    """Copy a file or directory."""
-    if os.path.isfile(src):
-        delete(dst)
-        shutil.copy(src, dst)
-    elif os.path.isdir(src):
-        dir_util.copy_tree(src, dst)
+def copy_dir_contents(src, dst):
+    """Copy the contents of a directory."""
+    for fpath in glob.glob('{}/*'.format(src)):
+        dest_path = os.path.join(dst, os.path.split(fpath)[-1])
+        if os.path.isdir(fpath):
+            shutil.copytree(fpath, dest_path)
+        else:
+            shutil.copyfile(fpath, dest_path)
 
 
 def delete(path):  # pragma: no cover (integration test)
@@ -202,3 +203,12 @@ def delete(path):  # pragma: no cover (integration test)
     elif os.path.isfile(path):
         log.trace("deleting '{}'...".format(path))
         os.remove(path)
+
+
+def delete_contents(dirname):
+    """Delete the contents of a directory."""
+    for file in glob.glob('{}/*'.format(dirname)):
+        if os.path.isdir(file):
+            shutil.rmtree(os.path.join(dirname, file))
+        else:
+            os.remove(os.path.join(dirname, file))

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -207,6 +207,12 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         # Yield items
         yield from list(self._items)
 
+    def copy_assets(self, dest):
+        """Copy the contents of the assets folder to the published assets folder."""
+        if not self.assets:
+            return
+        common.copy_dir_contents(self.assets, dest)
+
     # properties #############################################################
 
     @property

--- a/doorstop/core/test/__init__.py
+++ b/doorstop/core/test/__init__.py
@@ -144,6 +144,7 @@ class MockDataMixIn:  # pylint: disable=W0232,R0903
                        _file="links: [sys1]\ntext: 'Heading 2'\nlevel: 2.1.0\n"
                        "normative: false"),
     ]
+    document.copy_assets = Mock()
     document.assets = None
 
     item3 = MockItem('path/to/req4.yml', _file=(

--- a/doorstop/core/test/test_all.py
+++ b/doorstop/core/test/test_all.py
@@ -559,17 +559,6 @@ class TestPublisher(unittest.TestCase):
         self.assertIs(path, path2)
         self.assertTrue(os.path.isfile(path))
 
-    def test_publish_empty_tree(self):
-        """Verify a directory is not created when no documents to publish"""
-        mock_tree = Mock()
-        mock_tree.documents = []
-        dirpath = os.path.join(self.temp, 'gen')
-        # Act
-        path2 = core.publisher.publish(mock_tree, dirpath, index=True)
-        # Assert
-        self.assertIs(None, path2)
-        self.assertFalse(os.path.exists(dirpath))
-
     def test_publish_bad_link(self):
         """Verify a tree can be published with bad links."""
         item = self.document.add_item()

--- a/doorstop/core/test/test_exporter.py
+++ b/doorstop/core/test/test_exporter.py
@@ -1,7 +1,7 @@
 """Unit tests for the doorstop.core.exporter module."""
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 
 import os
 import tempfile
@@ -15,6 +15,7 @@ from doorstop.core.test import MockDataMixIn
 class TestModule(MockDataMixIn, unittest.TestCase):
     """Unit tests for the doorstop.core.exporter module."""
 
+    @patch('os.path.isdir', Mock(return_value=False))
     @patch('os.makedirs')
     @patch('doorstop.core.exporter.export_file')
     def test_export_document(self, mock_export_file, mock_makedirs):
@@ -35,6 +36,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
         self.assertRaises(DoorstopError,
                           exporter.export, self.document, 'a.yml', '.a')
 
+    @patch('os.path.isdir', Mock(return_value=False))
     @patch('os.makedirs')
     @patch('builtins.open')
     def test_export_tree(self, mock_open, mock_makedirs):
@@ -61,6 +63,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
         self.assertEqual(0, mock_makedirs.call_count)
         self.assertEqual(0, mock_open.call_count)
 
+    @patch('os.path.isdir', Mock(return_value=False))
     @patch('os.makedirs')
     @patch('doorstop.common.write_lines')
     def test_export_document_lines(self, mock_write_lines, mock_makedirs):


### PR DESCRIPTION
Multiple documents can have assets directories which are merged in the publish location.

Should close #223 