### PR TITLE
Deleting a document should not delete the directory unless it is empty

### DIFF
--- a/doorstop/core/vcs/git.py
+++ b/doorstop/core/vcs/git.py
@@ -23,7 +23,7 @@ class WorkingCopy(BaseWorkingCopy):
         self.call('git', 'add', self.relpath(path))
 
     def delete(self, path):
-        self.call('git', 'rm', '-r', self.relpath(path), '--force', '--quiet')
+        self.call('git', 'rm', self.relpath(path), '--force', '--quiet')
 
     def commit(self, message=None):
         message = message or input("Commit message: ")  # pylint: disable=W0141

--- a/doorstop/core/vcs/mockvcs.py
+++ b/doorstop/core/vcs/mockvcs.py
@@ -1,5 +1,5 @@
 """Plug-in module to simulate the storage of requirements in a repository."""
-
+import os
 
 from doorstop import common
 from doorstop.core.vcs.base import BaseWorkingCopy
@@ -26,7 +26,8 @@ class WorkingCopy(BaseWorkingCopy):
         log.debug("$ simulated add on: {}...".format(path))
 
     def delete(self, path):
-        log.debug("$ simulated delete on: {}...".format(path))
+        os.remove(path)
+        log.debug("$ Deleted {}...".format(path))
 
     def commit(self, message=None):
         log.debug("$ simulated commit")

--- a/doorstop/core/vcs/test/test_commands.py
+++ b/doorstop/core/vcs/test/test_commands.py
@@ -73,7 +73,7 @@ class TestGit(BaseTestCase, unittest.TestCase):
     def test_delete(self, mock_call):
         """Verify Git can delete files."""
         self.delete()
-        calls = [call(("git", "rm", "-r", self.path, "--force", "--quiet"))]
+        calls = [call(("git", "rm", self.path, "--force", "--quiet"))]
         mock_call.assert_has_calls(calls)
 
     def test_commit(self, mock_call):


### PR DESCRIPTION
Deleting a document no longer deletes the folder it contains as that folder could contain assets or have been incorrectly entered and point to some other directory containing non doorstop data.

This solves #234, which I think only affects git.