### PR TITLE
Items can now be added or deleted during reorder

### DIFF
--- a/docs/cli/reordering.md
+++ b/docs/cli/reordering.md
@@ -1,0 +1,63 @@
+# Documents Headings
+
+The items in a document are arranged according to their level attribute, with levels ending in .0
+creating headings and the subsequent items forming sub headings.
+
+A document can contain an arbitraty number of headings and sub headings.
+
+A normative heading item will display the item's uid as the heading text. A non normative heading
+displays the first line of the item text, with any subsequent text displayed in the body of the heading. 
+
+
+# Automatic item reordering
+
+Items in a document can be automatically reordered to remove gaps or duplicate entries in item headings.
+
+```sh
+$ doorstop reorder --auto REQ
+building tree...
+reordering document REQ...
+reordered document: REQ
+```
+
+# Manual item reordering
+
+Manual reordering creates an index.yml file in the document directory which describes the desired outline 
+of the document. The index.yml is edited, changing the indentation and order of the items to update the 
+levels of each item.
+
+```sh
+$ doorstop reorder --tool vi REQ
+building tree...
+reorder from 'reqs/index.yml'? [y/n] y
+reordering document REQ...
+reordered document: REQ
+```
+## Adding a new item
+
+An item can be added by adding a new line to the index.yml containing an unknown UID, e.g. new. 
+A comment following the new item ID can be used to set the item text. 
+If the line after a new item is further indented the item is treated as a heading and marked
+as non normative.
+
+```yaml
+###############################################################################
+# THIS TEMPORARY FILE WILL BE DELETED AFTER DOCUMENT REORDERING
+# MANUALLY INDENT, DEDENT, & MOVE ITEMS TO THEIR DESIRED LEVEL
+# A NEW ITEM WILL BE ADDED FOR ANY UNKNOWN IDS, i.e. - new: 
+# THE COMMENT WILL BE USED AS THE ITEM TEXT FOR NEW ITEMS
+# CHANGES WILL BE REFLECTED IN THE ITEM FILES AFTER CONFIRMATION
+###############################################################################
+
+initial: 1.0
+outline:
+    - REQ018: # Overview
+        - REQ019: # Doorstop is a requirements management tool that leverage...
+        - NEW: # The text of a new item
+    - NEW: # A new heading
+        - NEW: # The text of a new ite,
+```
+
+## Deleting an item
+
+Deleting a line from index.yml will result in the item being deleted.

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -306,7 +306,7 @@ def _lines_markdown(obj, linkify=False, **kwargs):
             text_lines = item.text.splitlines()
             # Level and Text
             if settings.PUBLISH_HEADING_LEVELS:
-                standard = "{h} {l} {t}".format(h=heading, l=level, t=text_lines[0])
+                standard = "{h} {l} {t}".format(h=heading, l=level, t=text_lines[0] if text_lines else '')
             else:
                 standard = "{h} {t}".format(h=heading, t=item.text)
             attr_list = _format_md_attr_list(item, linkify)
@@ -442,7 +442,8 @@ def _table_of_contents_md(obj, linkify=None):
             prefix += '* '
 
         if item.heading:
-            heading = item.text.splitlines()[0]
+            lines = item.text.splitlines()
+            heading = lines[0] if lines else ''
         else:
             heading = item.uid
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ pages:
 - Home: index.md
 - Command-line Interface:
   - Creating Documents: cli/creation.md
+  - Reordering Documents: cli/reordering.md
   - Validating Requirements: cli/validation.md
   - Publishing Documents: cli/publishing.md
   - Importing and Exporting: cli/interchange.md


### PR DESCRIPTION
This adds the feature discussed in #229.

The item text for new items is taken from the comment, so new items look the same as existing items, i.e.

```
    - TUT001: # This is an existing requirement
    - new: # This is the new item text
```

