### PR TITLE
The html template (css and js) assets are now installed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.rst *.txt *.md
 recursive-include docs *.rst *.txt *.md
 graft */files
 graft */*/files
+graft doorstop/core/files/assets

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     author_email='jacebrowning@gmail.com',
 
     packages=setuptools.find_packages(),
-    package_data={'doorstop.core': ['files/*']},
+    package_data={'doorstop.core': ['files/*', 'files/assets/_css/*', 'files/assets/_js/*']},
 
     entry_points={
         'console_scripts': [CLI + ' = doorstop.cli.main:main',


### PR DESCRIPTION
I tried installing from git to another computer and noticed that the _css and _js folders were missing from the published assets.