### PR TITLE
Work around a bug in Python 2.7 & 3.3 which prevents installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     author_email='jacebrowning@gmail.com',
 
     packages=setuptools.find_packages(),
-    package_data={'doorstop.core': ['files/*', 'files/assets/_css/*', 'files/assets/_js/*']},
+    package_data={'doorstop.core': ['files/*.html', 'files/*.css', 'files/assets/_css/*', 'files/assets/_js/*']},
 
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     author_email='jacebrowning@gmail.com',
 
     packages=setuptools.find_packages(),
-    package_data={'doorstop.core': ['files/*.html', 'files/*.css', 'files/assets/_css/*', 'files/assets/_js/*']},
+    package_data={'doorstop.core': ['files/*.html', 'files/*.css', 'files/assets/doorstop/*']},
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
See https://bugs.python.org/issue19286. Currently the installer fails
when trying to copy a directory in core/files/.