### PR TITLE
Escape quotes when reading the reorder index

### DIFF
--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -443,7 +443,8 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         yield "outline:"
         for item in items:
             space = "    " * item.depth
-            comment = item.text.replace('\n', ' ') or item.ref
+            lines = item.text.strip().splitlines()
+            comment = lines[0] if lines else ""
             line = space + "- {u}: # {c}".format(u=item.uid, c=comment)
             if len(line) > settings.MAX_LINE_LENGTH:
                 line = line[:settings.MAX_LINE_LENGTH - 3] + '...'
@@ -460,18 +461,17 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
             if m:
                 prefix = m.group(1)
                 uid = m.group(2)
-                item_text = m.group(3)
+                item_text = m.group(3).replace('"', '\\"')
                 yaml_text.append('{p}{u}:'.format(p=prefix, u=uid))
                 yaml_text.append('    {p}- text: "{t}"'.format(p=prefix, t=item_text))
             else:
                 yaml_text.append(line)
-        return '\n'.join(yaml_text)
+        return common.load_yaml('\n'.join(yaml_text), path)
 
     @staticmethod
     def _reorder_from_index(document, path):
         """Reorder a document's item from the index."""
-        text = document._read_index(path)
-        data = common.load_yaml(text, path)
+        data = document._read_index(path)
         # Read updated values
         initial = data.get('initial', 1.0)
         outline = data.get('outline', [])

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -288,7 +288,7 @@ def _chunks(text, width, indent):
                              subsequent_indent=' ' * indent)
 
 
-def _lines_markdown(obj, linkify=False):
+def _lines_markdown(obj, **kwargs):
     """Yield lines for a Markdown report.
 
     :param obj: Item, list of Items, or Document to publish
@@ -297,6 +297,7 @@ def _lines_markdown(obj, linkify=False):
     :return: iterator of lines of text
 
     """
+    linkify = kwargs.get('linkify', False)
     for item in iter_items(obj):
 
         heading = '#' * item.depth

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -255,28 +255,23 @@ class TestDocument(unittest.TestCase):
         """Verify a document index can be read."""
         lines = '''initial: 1.2.3
 outline:
-            - REQ001: # Lorem ipsum d...
+        - REQ001: # Lorem ipsum d...
         - REQ003: # Unicode: -40° ±1%
-        - REQ004: # Hello, world!
-        - REQ002: # Hello, world!
+        - REQ004: # Hello, world! !['..
+        - REQ002: # Hello, world! !["...
         - REQ2-001: # Hello, world!'''
 
-        expected = '''initial: 1.2.3
-outline:
-            - REQ001:
-                - text: "Lorem ipsum d..."
-        - REQ003:
-            - text: "Unicode: -40° ±1%"
-        - REQ004:
-            - text: "Hello, world!"
-        - REQ002:
-            - text: "Hello, world!"
-        - REQ2-001:
-            - text: "Hello, world!"'''
+        expected = {'initial': '1.2.3',
+                    'outline': [{'REQ001': [{'text': 'Lorem ipsum d...'}]},
+                                {'REQ003': [{'text': 'Unicode: -40° ±1%'}]},
+                                {'REQ004': [{'text': "Hello, world! !['.."}]},
+                                {'REQ002': [{'text': 'Hello, world! !["...'}]},
+                                {'REQ2-001': [{'text': 'Hello, world!'}]}]}
         # Act
         with patch('builtins.open') as mock_open:
             mock_open.side_effect = lambda *args, **kw: mock.mock_open(read_data=lines).return_value
             actual = self.document._read_index('mock_path')
+            # Check string can be parsed as yaml
         # Assert
         self.assertEqual(expected, actual)
 
@@ -726,9 +721,8 @@ class TestDocumentReorder(unittest.TestCase):
                     Level('4')]
 
         # Act
-        self.document._read_index = MagicMock()
-        with patch('doorstop.common.load_yaml', Mock(return_value=data)):
-            Document._reorder_from_index(self.document, 'mock_path')
+        self.document._read_index = MagicMock(return_value=data)
+        Document._reorder_from_index(self.document, 'mock_path')
 
         # Assert
         self.document._read_index.assert_called_once_with('mock_path')
@@ -760,9 +754,8 @@ class TestDocumentReorder(unittest.TestCase):
                     Level('3.2.1'),
                     Level('4')]
         # Act
-        self.document._read_index = MagicMock()
-        with patch('doorstop.common.load_yaml', Mock(return_value=data)):
-            Document._reorder_from_index(self.document, 'mock_path')
+        self.document._read_index = MagicMock(return_value=data)
+        Document._reorder_from_index(self.document, 'mock_path')
 
         # Assert
         self.document._read_index.assert_called_once_with('mock_path')
@@ -795,9 +788,8 @@ class TestDocumentReorder(unittest.TestCase):
 
         mock_item = self.document.add_item()
         # Act
-        self.document._read_index = MagicMock()
-        with patch('doorstop.common.load_yaml', Mock(return_value=data)):
-            Document._reorder_from_index(self.document, 'mock_path')
+        self.document._read_index = MagicMock(return_value=data)
+        Document._reorder_from_index(self.document, 'mock_path')
 
         # Assert
         self.document._read_index.assert_called_once_with('mock_path')


### PR DESCRIPTION
If the first line of text includes

`["Image"](assets/image.png "Image)`

This can be truncated to

`REQ002 # ["....`

Which can't be parsed as valid yaml. This change escapes the quote character.

This fixes #247 