### PR TITLE
Include views/*.tpl when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setuptools.setup(
     author_email='jacebrowning@gmail.com',
 
     packages=setuptools.find_packages(),
-    package_data={'doorstop.core': ['files/*.html', 'files/*.css', 'files/assets/doorstop/*']},
+    package_data={'doorstop.core': ['files/*.html', 'files/*.css', 'files/assets/doorstop/*'],
+                  'views': ['*.tpl']},
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
I missed this off when the HTML navigation branch was added. Previously there will be a failure if you run doorstop-server outside of the Doorstop development directory because the template files aren't installed with the rest of Doorstop.