### PR TITLE
Remove '/r/n' from published html on windows

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -510,7 +510,7 @@ def _lines_html(obj, linkify=False, extensions=EXTENSIONS,
         except Exception:
             log.error("Problem parsing the template %s", template)
             raise
-        yield html
+        yield '\n'.join(html.split(os.linesep))
     else:
         yield body
 


### PR DESCRIPTION
Bottle is adding '/r/n' line endings on windows which breaks tests in test_all.py which is expecting '\n' line endings.