### PR TITLE
Add heading ids when publishing a standalone document

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -315,7 +315,7 @@ def _lines_markdown(obj, **kwargs):
                     t=text_lines[0] if text_lines else '')
             else:
                 standard = "{h} {t}".format(h=heading, t=item.text)
-            attr_list = _format_md_attr_list(item, linkify)
+            attr_list = _format_md_attr_list(item, True)
             yield standard + attr_list
             yield from text_lines[1:]
         else:
@@ -326,7 +326,7 @@ def _lines_markdown(obj, **kwargs):
                                                   lev=level, u=item.uid)
             else:
                 standard = "{h} {u}".format(h=heading, u=item.uid)
-            attr_list = _format_md_attr_list(item, linkify)
+            attr_list = _format_md_attr_list(item, True)
             yield standard + attr_list
 
             # Text
@@ -494,7 +494,7 @@ def _lines_html(obj, linkify=False, extensions=EXTENSIONS,
     body = markdown.markdown(text, extensions=extensions)
 
     if toc:
-        toc_md = _table_of_contents_md(obj, linkify)
+        toc_md = _table_of_contents_md(obj, True)
         toc_html = markdown.markdown(toc_md, extensions=extensions)
     else:
         toc_html = ''

--- a/doorstop/core/tests/files/published.md
+++ b/doorstop/core/tests/files/published.md
@@ -1,4 +1,4 @@
-### 1.2.3 REQ001
+### 1.2.3 REQ001 {#REQ001 }
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua.
@@ -11,7 +11,7 @@ deserunt mollit anim id est laborum.
 
 *Parent links: SYS001, SYS002*
 
-## 1.4 REQ003
+## 1.4 REQ003 {#REQ003 }
 
 Unicode: -40° ±1%
 
@@ -19,17 +19,17 @@ Unicode: -40° ±1%
 
 *Parent links: REQ001*
 
-## 1.6 REQ004
+## 1.6 REQ004 {#REQ004 }
 
 Hello, world!
 
-## 2.1 REQ002
+## 2.1 REQ002 {#REQ002 }
 
 Hello, world!
 
 *Child links: TST001, TST002*
 
-## 2.1 REQ2-001
+## 2.1 REQ2-001 {#REQ2-001 }
 
 Hello, world!
 

--- a/doorstop/core/tests/files/published2.html
+++ b/doorstop/core/tests/files/published2.html
@@ -14,16 +14,16 @@
       <div class="col-lg-2 hidden-sm hidden-xs">
           <nav id="TOC" class="nav nav-stacked fixed sidebar">
               <h3>Table of Contents</h3>
-<pre><code>    * 1.2.3 REQ001
-* 1.4 REQ003
-* 1.6 REQ004
-* 2.1 REQ002
-* 2.1 REQ2-001
+<pre><code>    * [1.2.3 REQ001](#REQ001)
+* [1.4 REQ003](#REQ003)
+* [1.6 REQ004](#REQ004)
+* [2.1 REQ002](#REQ002)
+* [2.1 REQ2-001](#REQ2-001)
 </code></pre>
           </nav>
       </div>
       <div class="col-lg-8" id="main">
-        <h3>1.2.3 REQ001</h3>
+        <h3 id="REQ001">1.2.3 REQ001</h3>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -33,17 +33,17 @@ eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.</p>
 <p><em>Links: SYS001, SYS002</em></p>
-<h2>1.4 REQ003</h2>
+<h2 id="REQ003">1.4 REQ003</h2>
 <p>Unicode: -40° ±1%</p>
 <blockquote>
 <p><code>external/text.txt</code> (line 3)</p>
 </blockquote>
 <p><em>Links: REQ001</em></p>
-<h2>1.6 REQ004</h2>
+<h2 id="REQ004">1.6 REQ004</h2>
 <p>Hello, world!</p>
-<h2>2.1 REQ002</h2>
+<h2 id="REQ002">2.1 REQ002</h2>
 <p>Hello, world!</p>
-<h2>2.1 REQ2-001</h2>
+<h2 id="REQ2-001">2.1 REQ2-001</h2>
 <p>Hello, world!</p>
 <p><em>Links: REQ001</em></p>
       </div>

--- a/doorstop/core/tests/files/published2.md
+++ b/doorstop/core/tests/files/published2.md
@@ -1,4 +1,4 @@
-### 1.2.3 REQ001
+### 1.2.3 REQ001 {#REQ001 }
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua.
@@ -11,7 +11,7 @@ deserunt mollit anim id est laborum.
 
 *Links: SYS001, SYS002*
 
-## 1.4 REQ003
+## 1.4 REQ003 {#REQ003 }
 
 Unicode: -40° ±1%
 
@@ -19,15 +19,15 @@ Unicode: -40° ±1%
 
 *Links: REQ001*
 
-## 1.6 REQ004
+## 1.6 REQ004 {#REQ004 }
 
 Hello, world!
 
-## 2.1 REQ002
+## 2.1 REQ002 {#REQ002 }
 
 Hello, world!
 
-## 2.1 REQ2-001
+## 2.1 REQ2-001 {#REQ2-001 }
 
 Hello, world!
 

--- a/doorstop/core/tests/test_publisher.py
+++ b/doorstop/core/tests/test_publisher.py
@@ -285,7 +285,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
     @patch('doorstop.settings.PUBLISH_CHILD_LINKS', False)
     def test_lines_markdown_item_normative(self):
         """Verify Markdown can be published from an item (normative)."""
-        expected = ("## 1.2 req4" + '\n\n'
+        expected = ("## 1.2 req4 {#req4 }" + '\n\n'
                     "This shall..." + '\n\n'
                     "> `Doorstop.sublime-project`" + '\n\n'
                     "*Links: sys4*" + '\n\n')
@@ -317,7 +317,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
     @patch('doorstop.settings.PUBLISH_CHILD_LINKS', False)
     def test_lines_markdown_item_without_body_levels(self):
         """Verify Markdown can be published from an item (no body levels)."""
-        expected = ("## req4" + '\n\n'
+        expected = ("## req4 {#req4 }" + '\n\n'
                     "This shall..." + '\n\n'
                     "> `Doorstop.sublime-project`" + '\n\n'
                     "*Links: sys4*" + '\n\n')
@@ -336,7 +336,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
 
     def test_lines_html_item(self):
         """Verify HTML can be published from an item."""
-        expected = '<h2>1.1 Heading</h2>\n'
+        expected = '<h2 id="req3">1.1 Heading</h2>\n'
         # Act
         lines = publisher.publish_lines(self.item, '.html')
         text = ''.join(line + '\n' for line in lines)
@@ -346,7 +346,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
     @patch('doorstop.settings.PUBLISH_HEADING_LEVELS', False)
     def test_lines_html_item_no_heading_levels(self):
         """Verify an item heading level can be ommitted."""
-        expected = '<h2>Heading</h2>\n'
+        expected = '<h2 id="req3">Heading</h2>\n'
         # Act
         lines = publisher.publish_lines(self.item, '.html')
         text = ''.join(line + '\n' for line in lines)


### PR DESCRIPTION
Fixes #257 by adding ids to headings.

Leaves linkify as false so that child/parent links aren't rendered as links to files that may not exist.

Depends on #274 to pass on windows