### PR TITLE
Only ignore relpaths, not entire paths

### DIFF
--- a/doorstop/core/vcs/base.py
+++ b/doorstop/core/vcs/base.py
@@ -22,7 +22,6 @@ class BaseWorkingCopy(object, metaclass=ABCMeta):
         self.path = path
         self._ignores_cache = None
         self._path_cache = None
-        self._show_ci_warning = True
 
     @staticmethod
     def relpath(path):
@@ -90,13 +89,13 @@ class BaseWorkingCopy(object, metaclass=ABCMeta):
             for dirpath, _, filenames in os.walk(self.path):
                 for filename in filenames:
                     path = os.path.join(dirpath, filename)
+                    relpath = os.path.relpath(path, self.path)
                     # Skip ignored paths
-                    if self.ignored(path):
+                    if self.ignored(relpath):
                         continue
                     # Skip hidden paths
-                    if os.path.sep + '.' in path:
+                    if os.path.sep + '.' in relpath:
                         continue
-                    relpath = os.path.relpath(path, self.path)
                     self._path_cache.append((path, filename, relpath))
         yield from self._path_cache
 
@@ -104,10 +103,5 @@ class BaseWorkingCopy(object, metaclass=ABCMeta):
         """Determine if a path matches an ignored pattern."""
         for pattern in self.ignores:
             if fnmatch.fnmatch(path, pattern):
-                if pattern == '*build*' and os.getenv('CI'):
-                    if self._show_ci_warning:
-                        log.critical("cannot ignore 'build' on the CI server")
-                        self._show_ci_warning = False
-                else:
-                    return True
+                return True
         return False

--- a/doorstop/core/vcs/tests/test_base.py
+++ b/doorstop/core/vcs/tests/test_base.py
@@ -42,11 +42,3 @@ class TestSampleWorkingCopy(unittest.TestCase):
         self.assertFalse(self.wc.ignored("not_ignored.txt"))
         self.assertTrue(self.wc.ignored("path/to/published.html"))
         self.assertTrue(self.wc.ignored("build/path/to/anything"))
-
-    @patch('os.environ', {'CI': 'true'})
-    def test_ignored_on_ci(self):
-        """Verify the build directory is not ignored during CI."""
-        self.assertTrue(self.wc.ignored("ignored.txt"))
-        self.assertFalse(self.wc.ignored("not_ignored.txt"))
-        self.assertTrue(self.wc.ignored("path/to/published.html"))
-        self.assertFalse(self.wc.ignored("build/path/to/anything"))


### PR DESCRIPTION
There was a problem when my project repo got checked out by a CI runner, where
it got placed into a '.../build/myproject' folder.

In .gitignore, there was a '/BUILD/' ignore path.

As a result, fnmatch.fnmatch(path, '*BUILD*') in BaseWorkingCopy.ignored
returned True (as I understand, it is case insensitive), eventually
resulting in my entire tree being ignored when searching for refs.

There was a 'fix' for this, which don't ignore '*build*' if the
environment variable 'CI' was set.  This didn't match my '*BUILD*'
pattern, so it didn't trigger.  Also, it would actually not ignore a
real 'build/' directory in my repository if there was one, so I consider
this a bug anyway.