### PR TITLE
Fix skipping of hidden paths

### DIFF
--- a/doorstop/core/vcs/base.py
+++ b/doorstop/core/vcs/base.py
@@ -94,7 +94,7 @@ class BaseWorkingCopy(object, metaclass=ABCMeta):
                     if self.ignored(relpath):
                         continue
                     # Skip hidden paths
-                    if os.path.sep + '.' in relpath:
+                    if os.path.sep + '.' in os.path.sep + relpath:
                         continue
                     self._path_cache.append((path, filename, relpath))
         yield from self._path_cache

--- a/doorstop/core/vcs/tests/test_base.py
+++ b/doorstop/core/vcs/tests/test_base.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 
 from doorstop.core.vcs.base import BaseWorkingCopy
+from doorstop.core.tests import ROOT
 
 
 class SampleWorkingCopy(BaseWorkingCopy):
@@ -42,3 +43,11 @@ class TestSampleWorkingCopy(unittest.TestCase):
         self.assertFalse(self.wc.ignored("not_ignored.txt"))
         self.assertTrue(self.wc.ignored("path/to/published.html"))
         self.assertTrue(self.wc.ignored("build/path/to/anything"))
+
+    @patch('os.environ', {})
+    def test_paths(self):
+        """Verify that paths are cached correctly."""
+        wc = SampleWorkingCopy(ROOT)
+        paths = [relpath for path, _, relpath in wc.paths]
+        self.assertEqual([], [x for x in paths if x.startswith('.git/')])
+        self.assertNotEqual([], [x for x in paths if x.startswith('doorstop/')])


### PR DESCRIPTION
1.4b1 introduced a bug where hidden paths in the project root directory
were not skipped (e.g. '.git' directory was not excluded from the paths cache).