### PR TITLE
Put headers on the same line in Markdown/HTML output

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -18,4 +18,4 @@ python setup.py install | indent
 
 puts-step "Generating HTML from requirements"
 touch .mockvcs
-doorstop publish all public | indent
+doorstop publish all public -b header | indent

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -329,7 +329,7 @@ def _lines_markdown(obj, **kwargs):
                 if item.header:
                     uid = '{h} <small>{u}</small>'.format(h=item.header, u=item.uid)
                 else:
-                    uid = '{u} <small>{u}</small>'.format(u=item.uid)
+                    uid = '{u}'.format(u=item.uid)
 
             # Level and UID
             if settings.PUBLISH_BODY_LEVELS:

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -324,15 +324,19 @@ def _lines_markdown(obj, **kwargs):
             yield from text_lines[1:]
         else:
 
+            uid = item.uid
+            if settings.ENABLE_HEADERS:
+                if item.header:
+                    uid = '{h} <small>{u}</small>'.format(h=item.header, u=item.uid)
+                else:
+                    uid = '{u} <small>{u}</small>'.format(u=item.uid)
+
             # Level and UID
             if settings.PUBLISH_BODY_LEVELS:
                 standard = "{h} {lev} {u}".format(h=heading,
-                                                  lev=level, u=item.uid)
+                                                  lev=level, u=uid)
             else:
-                standard = "{h} {u}".format(h=heading, u=item.uid)
-
-            if item.header:
-                standard = "{s} {h}".format(s=standard, h=item.header)
+                standard = "{h} {u}".format(h=heading, u=uid)
 
             attr_list = _format_md_attr_list(item, True)
             yield standard + attr_list
@@ -464,7 +468,7 @@ def _table_of_contents_md(obj, linkify=None):
             lines = item.text.splitlines()
             heading = lines[0] if lines else ''
         elif item.header:
-            heading = "{u} {h}".format(u=item.uid, h=item.header)
+            heading = "{h}".format(h=item.header)
         else:
             heading = item.uid
 

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -330,13 +330,12 @@ def _lines_markdown(obj, **kwargs):
                                                   lev=level, u=item.uid)
             else:
                 standard = "{h} {u}".format(h=heading, u=item.uid)
+
+            if item.header:
+                standard = "{s} {h}".format(s=standard, h=item.header)
+
             attr_list = _format_md_attr_list(item, True)
             yield standard + attr_list
-
-            # Item Description
-            if item.header:
-                yield ""  # break before text
-                yield heading + item.header
 
             # Text
             if item.text:
@@ -464,6 +463,8 @@ def _table_of_contents_md(obj, linkify=None):
         if item.heading:
             lines = item.text.splitlines()
             heading = lines[0] if lines else ''
+        elif item.header:
+            heading = "{u} {h}".format(u=item.uid, h=item.header)
         else:
             heading = item.uid
 

--- a/doorstop/core/tests/files_beta/published3.html
+++ b/doorstop/core/tests/files_beta/published3.html
@@ -14,14 +14,13 @@
       <div class="col-lg-2 hidden-sm hidden-xs">
           <nav id="TOC" class="nav nav-stacked fixed sidebar">
               <section class="section3"><h3>Table of Contents</h3>
-<pre><code>* [1.1 REQHEADER001](#REQHEADER001)
+<pre><code>* [1.1 REQHEADER001 Some Header for this Item](#REQHEADER001)
 </code></pre>
 </section>
           </nav>
       </div>
       <div class="col-lg-8" id="main">
-        <section class="section2" id="REQHEADER001"><h2>1.1 REQHEADER001</h2>
-</section><section class="section2"><h2>Some Header for this Item</h2>
+        <section class="section2" id="REQHEADER001"><h2>1.1 REQHEADER001 Some Header for this Item</h2>
 <p>This one has a header and its linked parent also has a header.</p>
 <p><em>Parent links:</em> <a href="SYSHEADER.html#SYSHEADER001">SYSHEADER001 header hello world</a></p>
 </section>

--- a/doorstop/core/tests/files_beta/published3.html
+++ b/doorstop/core/tests/files_beta/published3.html
@@ -14,13 +14,13 @@
       <div class="col-lg-2 hidden-sm hidden-xs">
           <nav id="TOC" class="nav nav-stacked fixed sidebar">
               <section class="section3"><h3>Table of Contents</h3>
-<pre><code>* [1.1 REQHEADER001 Some Header for this Item](#REQHEADER001)
+<pre><code>* [1.1 Some Header for this Item](#REQHEADER001)
 </code></pre>
 </section>
           </nav>
       </div>
       <div class="col-lg-8" id="main">
-        <section class="section2" id="REQHEADER001"><h2>1.1 REQHEADER001 Some Header for this Item</h2>
+        <section class="section2" id="REQHEADER001"><h2>1.1 Some Header for this Item <small>REQHEADER001</small></h2>
 <p>This one has a header and its linked parent also has a header.</p>
 <p><em>Parent links:</em> <a href="SYSHEADER.html#SYSHEADER001">SYSHEADER001 header hello world</a></p>
 </section>

--- a/reqs/REQ001.yml
+++ b/reqs/REQ001.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Assets
 level: 2.3
 links: []
 normative: true

--- a/reqs/REQ003.yml
+++ b/reqs/REQ003.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Identifiers
 level: 2.1
 links: []
 normative: true

--- a/reqs/REQ004.yml
+++ b/reqs/REQ004.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Formatting
 level: 2.2
 links: []
 normative: true

--- a/reqs/REQ007.yml
+++ b/reqs/REQ007.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Viewing documents
 level: 3.1
 links: []
 normative: true

--- a/reqs/REQ008.yml
+++ b/reqs/REQ008.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Interactive viewing
 level: 3.2
 links: []
 normative: true

--- a/reqs/REQ009.yml
+++ b/reqs/REQ009.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Baseline versions
 level: 3.3
 links: []
 normative: true

--- a/reqs/REQ011.yml
+++ b/reqs/REQ011.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Storing requirements
 level: 4.1
 links: []
 normative: true

--- a/reqs/REQ012.yml
+++ b/reqs/REQ012.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Change management
 level: 4.2
 links: []
 normative: true

--- a/reqs/REQ013.yml
+++ b/reqs/REQ013.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Author information
 level: 4.3
 links: []
 normative: true

--- a/reqs/REQ014.yml
+++ b/reqs/REQ014.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Scalability
 level: 4.4
 links: []
 normative: true

--- a/reqs/REQ015.yml
+++ b/reqs/REQ015.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Installation
 level: 4.5
 links: []
 normative: true

--- a/reqs/REQ016.yml
+++ b/reqs/REQ016.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Importing content
 level: 2.4
 links: []
 normative: true

--- a/reqs/REQ017.yml
+++ b/reqs/REQ017.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Exporting content
 level: 2.5
 links: []
 normative: true

--- a/reqs/REQ019.yml
+++ b/reqs/REQ019.yml
@@ -1,5 +1,7 @@
 active: true
 derived: false
+header: |
+  Introduction
 level: 1.1
 links: []
 normative: false


### PR DESCRIPTION
In the newly added 'header' beta feature (see #31), the header was added on a separate line in the Markdown and HTML outputs, like this:

```
## 1.1 REQ002 {#REQ002 }

##Header

Text ...
```

But the 'text' output does something different and puts the header to the right of the UID.  I believe this is the intended format for this feature, so this commit changes the above output to:

```
## 1.1 REQ002 Header {#REQ002 }

Text ...
```

The TOC entry in the HTML output is updated accordingly.