### PR TITLE
Indent HTML sections based on level

### DIFF
--- a/doorstop/core/files/assets/doorstop/general.css
+++ b/doorstop/core/files/assets/doorstop/general.css
@@ -3,3 +3,13 @@ body {
     padding-top: 20px;
     padding-right: 20px;
 }
+
+/* indent everything within a section */
+section > * {
+    margin-left: 30px;
+}
+
+/* don't indent the section header */
+section > :first-child {
+    margin-left: 0px;
+}

--- a/doorstop/core/files/assets/doorstop/sidebar.css
+++ b/doorstop/core/files/assets/doorstop/sidebar.css
@@ -64,3 +64,8 @@
 .sidebar .nav>.active>ul.nav {
     display: block;           
 }
+
+/* don't be affected by <section> indentation */
+.sidebar * {
+    margin-left: 0px;
+}

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -17,6 +17,7 @@ import bottle
 EXTENSIONS = (
     'markdown.extensions.extra',
     'markdown.extensions.sane_lists',
+    'mdx_outline',
 )
 CSS = os.path.join(os.path.dirname(__file__), 'files', 'doorstop.css')
 HTMLTEMPLATE = 'sidebar'

--- a/doorstop/core/tests/files/published.html
+++ b/doorstop/core/tests/files/published.html
@@ -13,17 +13,18 @@
     <div class="row">
       <div class="col-lg-2 hidden-sm hidden-xs">
           <nav id="TOC" class="nav nav-stacked fixed sidebar">
-              <h3>Table of Contents</h3>
+              <section class="section3"><h3>Table of Contents</h3>
 <pre><code>    * [1.2.3 REQ001](#REQ001)
 * [1.4 REQ003](#REQ003)
 * [1.6 REQ004](#REQ004)
 * [2.1 REQ002](#REQ002)
 * [2.1 REQ2-001](#REQ2-001)
 </code></pre>
+</section>
           </nav>
       </div>
       <div class="col-lg-8" id="main">
-        <h3 id="REQ001">1.2.3 REQ001</h3>
+        <section class="section3" id="REQ001"><h3>1.2.3 REQ001</h3>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -33,21 +34,22 @@ eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.</p>
 <p><em>Parent links:</em> <a href="SYS.html#SYS001">SYS001</a>, <a href="SYS.html#SYS002">SYS002</a></p>
-<h2 id="REQ003">1.4 REQ003</h2>
+</section><section class="section2" id="REQ003"><h2>1.4 REQ003</h2>
 <p>Unicode: -40° ±1%</p>
 <blockquote>
 <p><code>external/text.txt</code> (line 3)</p>
 </blockquote>
 <p><em>Parent links:</em> <a href="REQ.html#REQ001">REQ001</a></p>
-<h2 id="REQ004">1.6 REQ004</h2>
+</section><section class="section2" id="REQ004"><h2>1.6 REQ004</h2>
 <p>Hello, world!</p>
-<h2 id="REQ002">2.1 REQ002</h2>
+</section><section class="section2" id="REQ002"><h2>2.1 REQ002</h2>
 <p>Hello, world!</p>
 <p><em>Child links:</em> <a href="TST.html#TST001">TST001</a>, <a href="TST.html#TST002">TST002</a></p>
-<h2 id="REQ2-001">2.1 REQ2-001</h2>
+</section><section class="section2" id="REQ2-001"><h2>2.1 REQ2-001</h2>
 <p>Hello, world!</p>
 <p><em>Parent links:</em> <a href="REQ.html#REQ001">REQ001</a></p>
 <p><em>Child links:</em> <a href="TST.html#TST001">TST001</a></p>
+</section>
       </div>
     </div>
 </div>

--- a/doorstop/core/tests/files/published2.html
+++ b/doorstop/core/tests/files/published2.html
@@ -13,17 +13,18 @@
     <div class="row">
       <div class="col-lg-2 hidden-sm hidden-xs">
           <nav id="TOC" class="nav nav-stacked fixed sidebar">
-              <h3>Table of Contents</h3>
+              <section class="section3"><h3>Table of Contents</h3>
 <pre><code>    * [1.2.3 REQ001](#REQ001)
 * [1.4 REQ003](#REQ003)
 * [1.6 REQ004](#REQ004)
 * [2.1 REQ002](#REQ002)
 * [2.1 REQ2-001](#REQ2-001)
 </code></pre>
+</section>
           </nav>
       </div>
       <div class="col-lg-8" id="main">
-        <h3 id="REQ001">1.2.3 REQ001</h3>
+        <section class="section3" id="REQ001"><h3>1.2.3 REQ001</h3>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -33,19 +34,20 @@ eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.</p>
 <p><em>Links: SYS001, SYS002</em></p>
-<h2 id="REQ003">1.4 REQ003</h2>
+</section><section class="section2" id="REQ003"><h2>1.4 REQ003</h2>
 <p>Unicode: -40° ±1%</p>
 <blockquote>
 <p><code>external/text.txt</code> (line 3)</p>
 </blockquote>
 <p><em>Links: REQ001</em></p>
-<h2 id="REQ004">1.6 REQ004</h2>
+</section><section class="section2" id="REQ004"><h2>1.6 REQ004</h2>
 <p>Hello, world!</p>
-<h2 id="REQ002">2.1 REQ002</h2>
+</section><section class="section2" id="REQ002"><h2>2.1 REQ002</h2>
 <p>Hello, world!</p>
-<h2 id="REQ2-001">2.1 REQ2-001</h2>
+</section><section class="section2" id="REQ2-001"><h2>2.1 REQ2-001</h2>
 <p>Hello, world!</p>
 <p><em>Links: REQ001</em></p>
+</section>
       </div>
     </div>
 </div>

--- a/doorstop/core/tests/files_beta/published3.html
+++ b/doorstop/core/tests/files_beta/published3.html
@@ -13,16 +13,18 @@
     <div class="row">
       <div class="col-lg-2 hidden-sm hidden-xs">
           <nav id="TOC" class="nav nav-stacked fixed sidebar">
-              <h3>Table of Contents</h3>
+              <section class="section3"><h3>Table of Contents</h3>
 <pre><code>* [1.1 REQHEADER001](#REQHEADER001)
 </code></pre>
+</section>
           </nav>
       </div>
       <div class="col-lg-8" id="main">
-        <h2 id="REQHEADER001">1.1 REQHEADER001</h2>
-<h2>Some Header for this Item</h2>
+        <section class="section2" id="REQHEADER001"><h2>1.1 REQHEADER001</h2>
+</section><section class="section2"><h2>Some Header for this Item</h2>
 <p>This one has a header and its linked parent also has a header.</p>
 <p><em>Parent links:</em> <a href="SYSHEADER.html#SYSHEADER001">SYSHEADER001 header hello world</a></p>
+</section>
       </div>
     </div>
 </div>

--- a/doorstop/core/tests/test_publisher.py
+++ b/doorstop/core/tests/test_publisher.py
@@ -336,7 +336,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
 
     def test_lines_html_item(self):
         """Verify HTML can be published from an item."""
-        expected = '<h2 id="req3">1.1 Heading</h2>\n'
+        expected = '<section class="section2" id="req3"><h2>1.1 Heading</h2>\n</section>\n'
         # Act
         lines = publisher.publish_lines(self.item, '.html')
         text = ''.join(line + '\n' for line in lines)
@@ -346,7 +346,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
     @patch('doorstop.settings.PUBLISH_HEADING_LEVELS', False)
     def test_lines_html_item_no_heading_levels(self):
         """Verify an item heading level can be ommitted."""
-        expected = '<h2 id="req3">Heading</h2>\n'
+        expected = '<section class="section2" id="req3"><h2>Heading</h2>\n</section>\n'
         # Act
         lines = publisher.publish_lines(self.item, '.html')
         text = ''.join(line + '\n' for line in lines)
@@ -355,7 +355,7 @@ class TestModule(MockDataMixIn, unittest.TestCase):
 
     def test_lines_html_item_linkify(self):
         """Verify HTML (hyper) can be published from an item."""
-        expected = '<h2 id="req3">1.1 Heading</h2>\n'
+        expected = '<section class="section2" id="req3"><h2>1.1 Heading</h2>\n</section>\n'
         # Act
         lines = publisher.publish_lines(self.item, '.html', linkify=True)
         text = ''.join(line + '\n' for line in lines)

--- a/setup.py
+++ b/setup.py
@@ -86,5 +86,6 @@ setuptools.setup(
         "bottle == 0.12.13",
         "requests >= 2, < 3",
         "pyficache == 0.3.1",
+        "mdx_outline >= 1.3.0, < 2",
     ],
 )


### PR DESCRIPTION
Implements #128 by using the mdx_outline extension for python-markdown,
which groups every heading into an appropriate `<section>` tag according
to its header level.