### PR TITLE
When publishing markdown test in headings is duplicated #277

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -318,7 +318,7 @@ def _lines_markdown(obj, **kwargs):
                     h=heading, lev=level,
                     t=text_lines[0] if text_lines else '')
             else:
-                standard = "{h} {t}".format(h=heading, t=item.text)
+                standard = "{h} {t}".format(h=heading, t=text_lines[0] if text_lines else '')
             attr_list = _format_md_attr_list(item, True)
             yield standard + attr_list
             yield from text_lines[1:]

--- a/doorstop/core/tests/test_publisher.py
+++ b/doorstop/core/tests/test_publisher.py
@@ -226,6 +226,22 @@ class TestModule(MockDataMixIn, unittest.TestCase):
         # Assert
         self.assertEqual(expected, text)
 
+    
+    @patch('doorstop.settings.PUBLISH_HEADING_LEVELS', False)
+    def test_multi_line_heading_to_markdown_no_heading_levels(self):
+        """Verify a multi line heading is published as a heading, without level, with an attribute equal to the item id"""
+        item = MockItemAndVCS('path/to/req3.yml',
+                              _file=("links: [sys3]" + '\n'
+                                     "text: 'Heading\n\nThis section describes publishing.'" + '\n'
+                                     "level: 1.1.0" + '\n'
+                                     "normative: false"))
+        expected = "## Heading {#req3 }\nThis section describes publishing.\n\n"
+        lines = publisher.publish_lines(item, '.md', linkify=True)
+        # Act
+        text = ''.join(line + '\n' for line in lines)
+        # Assert
+        self.assertEqual(expected, text)
+
     @patch('doorstop.settings.PUBLISH_CHILD_LINKS', False)
     def test_lines_text_item_normative(self):
         """Verify text can be published from an item (normative)."""


### PR DESCRIPTION
In markdown Every text line were printed into the heading when disabling heading level with command line "--no-level all"

see issue:  #277 