### PR TITLE
OS specific end-line

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,46 @@
+# Setup
+
+Doorstop can require different settings for different systems.
+This page contains recommendations for setting up your repository to
+accomodate a variety of systems.
+
+**Intended Audience:** CVS Repository Administrator
+
+## Windows
+
+### Git repository
+
+Windows deals with line-endings differently to most systems, favouring `CRLF` (`\r\n`) over the more traditional `LF` (`\n`).
+
+**Symptom:**\
+The `YAML` files saved and revision-controlled by Doorstop have `LF`
+line-endings, which can cause the following warnings:
+
+```
+(doorstop) C:\temp\doorstop>doorstop reorder --auto TS
+building tree...
+reordering document TS...
+warning: LF will be replaced by CRLF in tests/sys/TS003.yml.
+The file will have its original line endings in your working directory.
+warning: LF will be replaced by CRLF in tests/sys/TS001.yml.
+The file will have its original line endings in your working directory.
+warning: LF will be replaced by CRLF in tests/sys/TS002.yml.
+The file will have its original line endings in your working directory.
+warning: LF will be replaced by CRLF in tests/sys/TS004.yml.
+The file will have its original line endings in your working directory.
+reordered document: TS
+```
+
+These warnings come from Git as a sub-process of the main Doorstop processes,
+so the solution to this problem is a Git setting.
+
+**Recommendation:**\
+Add the following `.gitattributes`
+
+```
+*.yml core.safeclrf=false
+```
+
+From [Git's documentation](https://git-scm.com/docs/gitattributes):
+
+> If `core.safecrlf` is set to "true" or "warn", Git verifies if the conversion is reversible for the current setting of `core.autocrlf`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,7 @@ Doorstop can require different settings for different systems.
 This page contains recommendations for setting up your repository to
 accomodate a variety of systems.
 
-**Intended Audience:** CVS Repository Administrator
+**Intended Audience:** Version Control System (VCS) Repository Administrator
 
 ## Windows
 

--- a/doorstop/core/base.py
+++ b/doorstop/core/base.py
@@ -280,7 +280,13 @@ class BaseFileObject(metaclass=abc.ABCMeta):
         :return: text to write to a file
 
         """
-        return yaml.dump(data, default_flow_style=False, allow_unicode=True)
+        text = yaml.dump(data, default_flow_style=False, allow_unicode=True)
+
+        # yaml.dump always ends lines with '\n'... make the dump os-specific
+        if os.linesep != '\n':
+            text.replace('\n', os.linesep)
+
+        return text
 
     # properties #############################################################
 

--- a/doorstop/core/base.py
+++ b/doorstop/core/base.py
@@ -280,13 +280,7 @@ class BaseFileObject(metaclass=abc.ABCMeta):
         :return: text to write to a file
 
         """
-        text = yaml.dump(data, default_flow_style=False, allow_unicode=True)
-
-        # yaml.dump always ends lines with '\n'... make the dump os-specific
-        if os.linesep != '\n':
-            text.replace('\n', os.linesep)
-
-        return text
+        return yaml.dump(data, default_flow_style=False, allow_unicode=True)
 
     # properties #############################################################
 

--- a/doorstop/core/base.py
+++ b/doorstop/core/base.py
@@ -284,7 +284,7 @@ class BaseFileObject(metaclass=abc.ABCMeta):
 
         # yaml.dump always ends lines with '\n'... make the dump os-specific
         if os.linesep != '\n':
-            text.replace('\n', os.linesep)
+            text = text.replace('\n', os.linesep)
 
         return text
 

--- a/doorstop/core/base.py
+++ b/doorstop/core/base.py
@@ -284,7 +284,7 @@ class BaseFileObject(metaclass=abc.ABCMeta):
 
         # yaml.dump always ends lines with '\n'... make the dump os-specific
         if os.linesep != '\n':
-            text = text.replace('\n', os.linesep)
+            text.replace('\n', os.linesep)
 
         return text
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ extra_javascript: []
 
 pages:
 - Home: index.md
+- Setup: setup.md
 - Command-line Interface:
   - Creating Documents: cli/creation.md
   - Reordering Documents: cli/reordering.md


### PR DESCRIPTION
Save YAML files with line-endings prescribed by the executing OS (#310).
Doesn't effect loading of yaml:

_note_
```
>>> with open('REQ001.yml', 'r') as fh:
...     content = fh.read()
... 
>>> import yaml
>>> yaml.load(content) == yaml.load(content.replace('\n', '\r\n'))
True
```
