### PR TITLE
Add --edit option to 'doorstop add' command.

### DIFF
--- a/doorstop/cli/commands.py
+++ b/doorstop/cli/commands.py
@@ -124,6 +124,10 @@ def run_add(args, cwd, _, catch=True):
             utilities.show("added item: {} ({})".format(item.uid,
                                                         item.relpath))
 
+        # Edit item if requested
+        if args.edit:
+            item.edit(tool=args.tool)
+
     if not success:
         return False
 

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -159,6 +159,7 @@ def _add(subs, shared):
                            "required if $EDITOR is not found in"
                            "environment). Useless option without --edit"))
 
+
 def _remove(subs, shared):
     """Configure the `doorstop remove` subparser."""
     info = "remove an item file from a document directory"

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -149,7 +149,15 @@ def _add(subs, shared):
     sub.add_argument('-l', '--level', help="desired item level (e.g. 1.2.3)")
     sub.add_argument('-c', '--count', default=1, type=utilities.positive_int,
                      help="number of items to create")
-
+    sub.add_argument('--edit', action='store_true',
+                     help=("Open default editor to edit the added item. "
+                           "Default editor can be set using the environment "
+                           "variable EDITOR."))
+    sub.add_argument('-T', '--tool', metavar='PROGRAM',
+                      default=EDITOR,
+                      help=("text editor to open the document item (only"
+                            "required if $EDITOR is not found in"
+                            "environment). Useless option without --edit"))
 
 def _remove(subs, shared):
     """Configure the `doorstop remove` subparser."""

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -154,10 +154,10 @@ def _add(subs, shared):
                            "Default editor can be set using the environment "
                            "variable EDITOR."))
     sub.add_argument('-T', '--tool', metavar='PROGRAM',
-                      default=EDITOR,
-                      help=("text editor to open the document item (only"
-                            "required if $EDITOR is not found in"
-                            "environment). Useless option without --edit"))
+                     default=EDITOR,
+                     help=("text editor to open the document item (only"
+                           "required if $EDITOR is not found in"
+                           "environment). Useless option without --edit"))
 
 def _remove(subs, shared):
     """Configure the `doorstop remove` subparser."""


### PR DESCRIPTION
This new option immediatly opens an editor
to edit the newly added item. Default editor can be
set with the environment variable EDITOR, or it can
be precised with -T option like in other commands.