### PR TITLE
Fix #24

### DIFF
--- a/doorstop/cli/commands.py
+++ b/doorstop/cli/commands.py
@@ -188,7 +188,7 @@ def run_edit(args, cwd, error, catch=True):
 
         # edit it
         if item:
-            item.edit(tool=args.tool)
+            item.edit(tool=args.tool, edit_all=args.all)
         else:
             _export_import(args, cwd, error, document, ext)
 

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -175,6 +175,10 @@ def _edit(subs, shared):
                           help=info, **shared)
     sub.add_argument('label',
                      help="item UID or document prefix to open for editing")
+    sub.add_argument('-a', '--all', action='store_true',
+                     help=("Edit the whole item with all its attributes. "
+                           "Without this option, only its text is opened for "
+                           "edition. Useless when editing a whole document."))
     group = sub.add_mutually_exclusive_group()
     group.add_argument('-i', '--item', action='store_true',
                        help="indicates the 'label' is an item UID")

--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -294,8 +294,8 @@ class TestEdit(unittest.TestCase):
 
     @patch('doorstop.core.editor.launch')
     def test_edit_item(self, mock_launch):
-        """Verify 'doorstop edit' can be called with an item."""
-        self.assertIs(None, main(['edit', 'tut2', '-T', 'my_editor']))
+        """Verify 'doorstop edit' can be called with an item (all)."""
+        self.assertIs(None, main(['edit', 'tut2', '-T', 'my_editor', '--all']))
         path = os.path.join(TUTORIAL, 'TUT002.yml')
         mock_launch.assert_called_once_with(os.path.normpath(path), tool='my_editor')
 

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -493,17 +493,30 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
     # actions ################################################################
 
     @auto_save
-    def edit(self, tool=None):
+    def edit(self, tool=None, edit_all=True):
         """Open the item for editing.
 
         :param tool: path of alternate editor
+        :param edit_all: True to edit the whole item,
+            False to only edit the text.
 
         """
         # Lock the item
         if self.tree:
             self.tree.vcs.lock(self.path)
-        # Open in an editor
-        editor.edit(self.path, tool=tool)
+        # Edit the whole file in an editor
+        if edit_all:
+            editor.edit(self.path, tool=tool)
+        # Edit only the text part in an editor
+        else:
+            # Edit the text in a temporary file
+            edited_text = editor.edit_tmp_content(title=str(self.uid),
+                                                  original_content=str(self.text),
+                                                  tool=tool)
+            # Save the text in the actual item file
+            self.text = edited_text
+            self.save()
+
         # Force reloaded
         self._loaded = False
 


### PR DESCRIPTION
Fix issue #24. Add --all option to `doorstop edit`.

Now, `doorstep edit ITEM` only the text part of the item by default.
To edit the whole item with all of its attributes, one must add the
--all or -a option to the command.

To edit the text part only, a temporary file is created to be edited
by the user, and then read by doorstop to update the actual item file.