### PR TITLE
Fix misuse of code blocks in Markdown files

### DIFF
--- a/docs/cli/interchange.md
+++ b/docs/cli/interchange.md
@@ -2,23 +2,27 @@
 
 Documents can be exported for editing or to exchange with other systems:
 
-    $ doorstop export TST
-    TST001:
-      active: true
-      dervied: false
-      level: 1
-      links:
-      - REQ001
-      normative: true
-      ref: ''
-      text: |
-        Verify the foobar will foo and bar.
+```sh
+$ doorstop export TST
+TST001:
+  active: true
+  dervied: false
+  level: 1
+  links:
+  - REQ001
+  normative: true
+  ref: ''
+  text: |
+    Verify the foobar will foo and bar.
+```
 
 Or a file can be created using one of the supported extensions:
 
-    $ doorstop export TST path/to/tst.csv
-    exporting TST to path/to/tst.csv...
-    exported: path/to/tst.csv
+```sh
+$ doorstop export TST path/to/tst.csv
+exporting TST to path/to/tst.csv...
+exported: path/to/tst.csv
+```
 
 Supported formats:
 
@@ -31,4 +35,6 @@ Supported formats:
 
 Items can be created/updated from the export formats:
 
-    $ doorstop import path/to/tst.csv TST
+```sh
+$ doorstop import path/to/tst.csv TST
+```

--- a/docs/cli/publishing.md
+++ b/docs/cli/publishing.md
@@ -2,7 +2,7 @@
 
 Individual documents can be displayed:
 
-```
+```sh
 $ doorstop publish TST
 ```
 
@@ -10,7 +10,7 @@ $ doorstop publish TST
 
 The collection of documents can be published as a webpage:
 
-```
+```sh
 $ doorstop publish all ./dist/
 ```
 
@@ -18,8 +18,10 @@ $ doorstop publish all ./dist/
 
 Or a file can be created using one of the supported extensions:
 
-    $ doorstop publish TST path/to/tst.md
-    publishing TST to path/to/tst.md...
+```sh
+$ doorstop publish TST path/to/tst.md
+publishing TST to path/to/tst.md...
+```
 
 Supported formats:
 

--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -1,7 +1,7 @@
 # Overview
 
 Doorstop items are files formatted using YAML. When a new item is added using
-```doorstop add```, Doorstop will create a YAML file and populate it with all
+`doorstop add`, Doorstop will create a YAML file and populate it with all
 required attributes (key-value pairs).
 
 Example item:
@@ -68,7 +68,7 @@ item has not yet been reviewed. Doorstop will use this to detect unreviewed
 changes to an item by comparing the current item fingerprint to the last
 reviewed fingerprint.
 
-You should not calculate this value manually, use ```doorstop review```.
+You should not calculate this value manually, use `doorstop review`.
 
 
 ### links
@@ -76,7 +76,7 @@ You should not calculate this value manually, use ```doorstop review```.
 A list of links to parent item(s). A link indicates a relationship between two
 items in the document tree.
 
-In the following example, ```REQ001``` is a parent to the item.
+In the following example, `REQ001` is a parent to the item.
 
 ```yaml
 links:
@@ -122,7 +122,7 @@ keyword. If the keyword is found in multiple lines or files, the first found
 will be used.
 
 A file is considered a text-file unless its file extension is listed in
-```SKIP_EXTS``` (settings.py).
+`SKIP_EXTS` (settings.py).
 
 #### Example: Reference keyword
 ```yaml
@@ -186,7 +186,7 @@ application through the REST interface or the Python API.
 
 #### Example:
 
-In this example, an extended attribute ```invented-by``` is added to the item.
+In this example, an extended attribute `invented-by` is added to the item.
 
 ```yaml
 invented-by: some.guy@email.com


### PR DESCRIPTION
- Change simple to triple backtick when code is in a text block.
- Change code blocks made of 4 spaces into code blocks made of backticks, with language label.