### PR TITLE
Expose document object to support better templating.

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -524,7 +524,7 @@ def _lines_html(obj, linkify=False, extensions=EXTENSIONS,
                                                      '..', 'views'))
             if 'baseurl' not in bottle.SimpleTemplate.defaults:
                 bottle.SimpleTemplate.defaults['baseurl'] = ''
-            html = bottle_template(template, body=body, toc=toc_html, parent=obj.parent, obj=obj)
+            html = bottle_template(template, body=body, toc=toc_html, parent=obj.parent, document=obj)
         except Exception:
             log.error("Problem parsing the template %s", template)
             raise

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -524,7 +524,7 @@ def _lines_html(obj, linkify=False, extensions=EXTENSIONS,
                                                      '..', 'views'))
             if 'baseurl' not in bottle.SimpleTemplate.defaults:
                 bottle.SimpleTemplate.defaults['baseurl'] = ''
-            html = bottle_template(template, body=body, toc=toc_html, parent=obj.parent)
+            html = bottle_template(template, body=body, toc=toc_html, parent=obj.parent, obj=obj)
         except Exception:
             log.error("Problem parsing the template %s", template)
             raise


### PR DESCRIPTION
When the document object is exposed for templating, you will be able to utilize doc obj attributes such as the current doc name, config, children, items, etc.