### PR TITLE
Make document mandatory for Item

### DIFF
--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -189,8 +189,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
             for filename in filenames:
                 path = os.path.join(dirpath, filename)
                 try:
-                    item = Item(path, root=self.root,
-                                document=self, tree=self.tree)
+                    item = Item(self, path, root=self.root, tree=self.tree)
                 except DoorstopError:
                     pass  # skip non-item files
                 else:

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -31,19 +31,6 @@ def requires_tree(func):
     return wrapped
 
 
-def requires_document(func):
-    """Require a document reference."""
-    @functools.wraps(func)
-    def wrapped(self, *args, **kwargs):
-        if not self.document:
-            name = func.__name__
-            msg = "`{}` can only be called with a document".format(name)
-            log.critical(msg)
-            return None
-        return func(self, *args, **kwargs)
-    return wrapped
-
-
 class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
     """Represents an item file with linkable text."""
 
@@ -58,7 +45,7 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
     DEFAULT_REF = ""
     DEFAULT_HEADER = Text()
 
-    def __init__(self, path, root=os.getcwd(), **kwargs):
+    def __init__(self, document, path, root=os.getcwd(), **kwargs):
         """Initialize an item from an existing file.
 
         :param path: path to Item file
@@ -84,7 +71,7 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         # Initialize the item
         self.path = path
         self.root = root
-        self.document = kwargs.get('document')
+        self.document = document
         self.tree = kwargs.get('tree')
         self.auto = kwargs.get('auto', Item.auto)
         # Set default values
@@ -142,7 +129,7 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         log.debug("creating item file at {}...".format(path2))
         Item._create(path2, name='item')
         # Initialize the item
-        item = Item(path2, root=root, document=document, tree=tree, auto=False)
+        item = Item(document, path2, root=root, tree=tree, auto=False)
         item.level = level if level is not None else item.level
         if auto or (auto is None and Item.auto):
             item.save()
@@ -475,7 +462,6 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
 
     @property
     @requires_tree
-    @requires_document
     def parent_documents(self):
         """Get a list of documents that this item's document should link to.
 

--- a/doorstop/core/tests/__init__.py
+++ b/doorstop/core/tests/__init__.py
@@ -90,7 +90,7 @@ class MockItemAndVCS(MockItem):  # pylint: disable=W0223,R0902
     """Mock item class with stubbed IO and a mock VCS reference."""
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(None, *args, **kwargs)
         self.tree = Mock()
         self.tree.vcs = WorkingCopy(None)
 
@@ -149,7 +149,7 @@ class MockDataMixIn:  # pylint: disable=W0232,R0903
     document.copy_assets = Mock()
     document.assets = None
 
-    item3 = MockItem('path/to/req4.yml', _file=(
+    item3 = MockItem(None, 'path/to/req4.yml', _file=(
         "links: [sys4]" + '\n'
         "text: 'This shall...'" + '\n'
         "ref: Doorstop.sublime-project" + '\n'

--- a/doorstop/core/tests/test_all.py
+++ b/doorstop/core/tests/test_all.py
@@ -46,7 +46,7 @@ class TestItem(unittest.TestCase):
     def setUp(self):
         self.path = os.path.join(FILES, 'REQ001.yml')
         self.backup = common.read_text(self.path)
-        self.item = core.Item(self.path)
+        self.item = core.Item(None, self.path)
         self.item.tree = Mock()
         self.item.tree.vcs = mockvcs.WorkingCopy(EMPTY)
 
@@ -58,7 +58,7 @@ class TestItem(unittest.TestCase):
         self.item.level = '1.2.3'
         self.item.text = "Hello, world!"
         self.item.links = ['SYS001', 'SYS002']
-        item2 = core.Item(os.path.join(FILES, 'REQ001.yml'))
+        item2 = core.Item(None, os.path.join(FILES, 'REQ001.yml'))
         self.assertEqual((1, 2, 3), item2.level)
         self.assertEqual("Hello, world!", item2.text)
         self.assertEqual(['SYS001', 'SYS002'], item2.links)
@@ -66,7 +66,7 @@ class TestItem(unittest.TestCase):
     @unittest.skipUnless(os.getenv(ENV), REASON)
     def test_find_ref(self):
         """Verify an item's external reference can be found."""
-        item = core.Item(os.path.join(FILES, 'REQ003.yml'))
+        item = core.Item(None, os.path.join(FILES, 'REQ003.yml'))
         item.tree = Mock()
         item.tree.vcs = mockvcs.WorkingCopy(ROOT)
         path, line = item.find_ref()
@@ -243,7 +243,7 @@ class TestTree(unittest.TestCase):
     def setUp(self):
         self.path = os.path.join(FILES, 'REQ001.yml')
         self.backup = common.read_text(self.path)
-        self.item = core.Item(self.path)
+        self.item = core.Item(None, self.path)
         self.tree = core.Tree(core.Document(SYS))
         self.tree._place(core.Document(FILES))
 

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -34,11 +34,11 @@ class TestItem(unittest.TestCase):
 
     def setUp(self):
         path = os.path.join('path', 'to', 'RQ001.yml')
-        self.item = MockItem(path)
+        self.item = MockItem(None, path)
 
     def test_init_invalid(self):
         """Verify an item cannot be initialized from an invalid path."""
-        self.assertRaises(DoorstopError, Item, 'not/a/path')
+        self.assertRaises(DoorstopError, Item, None, 'not/a/path')
 
     def test_object_references(self):
         """Verify a standalone item does not have object references."""
@@ -78,9 +78,9 @@ class TestItem(unittest.TestCase):
 
     def test_hash(self):
         """Verify items can be hashed."""
-        item1 = MockItem('path/to/fake1.yml')
-        item2 = MockItem('path/to/fake2.yml')
-        item3 = MockItem('path/to/fake2.yml')
+        item1 = MockItem(None, 'path/to/fake1.yml')
+        item2 = MockItem(None, 'path/to/fake2.yml')
+        item3 = MockItem(None, 'path/to/fake2.yml')
         my_set = set()
         # Act
         my_set.add(item1)
@@ -95,11 +95,11 @@ class TestItem(unittest.TestCase):
 
     def test_lt(self):
         """Verify items can be compared."""
-        item1 = MockItem('path/to/fake1.yml')
+        item1 = MockItem(None, 'path/to/fake1.yml')
         item1.level = (1, 1)
-        item2 = MockItem('path/to/fake1.yml')
+        item2 = MockItem(None, 'path/to/fake1.yml')
         item2.level = (1, 1, 1)
-        item3 = MockItem('path/to/fake1.yml')
+        item3 = MockItem(None, 'path/to/fake1.yml')
         item3.level = (1, 1, 2)
         self.assertLess(item1, item2)
         self.assertLess(item2, item3)
@@ -362,14 +362,14 @@ class TestItem(unittest.TestCase):
     def test_link_by_item(self):
         """Verify links can be added to an item (by item)."""
         path = os.path.join('path', 'to', 'ABC123.yml')
-        item = MockItem(path)
+        item = MockItem(None, path)
         self.item.link(item)
         self.assertEqual(['ABC123'], self.item.links)
 
     def test_unlink_by_item(self):
         """Verify links can be removed (by item)."""
         path = os.path.join('path', 'to', 'ABC123.yml')
-        item = MockItem(path)
+        item = MockItem(None, path)
         self.item.links = ['ABC123']
         self.item.unlink(item)
         self.assertEqual([], self.item.links)
@@ -430,11 +430,6 @@ class TestItem(unittest.TestCase):
         documents = self.item.parent_documents
         # Assert
         self.assertEqual([], documents)
-
-    def test_parent_documents_no_document(self):
-        """Verify 'parent_documents' is only valid with a document."""
-        self.item.tree = Mock()
-        self.assertIs(None, self.item.parent_documents)
 
     @patch('doorstop.settings.CACHE_PATHS', False)
     def test_find_ref(self):
@@ -528,13 +523,13 @@ class TestItem(unittest.TestCase):
 
     def test_invalid_file_name(self):
         """Verify an invalid file name cannot be a requirement."""
-        self.assertRaises(DoorstopError, MockItem, "path/to/REQ.yaml")
-        self.assertRaises(DoorstopError, MockItem, "path/to/001.yaml")
+        self.assertRaises(DoorstopError, MockItem, None, "path/to/REQ.yaml")
+        self.assertRaises(DoorstopError, MockItem, None, "path/to/001.yaml")
 
     def test_invalid_file_ext(self):
         """Verify an invalid file extension cannot be a requirement."""
-        self.assertRaises(DoorstopError, MockItem, "path/to/REQ001")
-        self.assertRaises(DoorstopError, MockItem, "path/to/REQ001.txt")
+        self.assertRaises(DoorstopError, MockItem, None, "path/to/REQ001")
+        self.assertRaises(DoorstopError, MockItem, None, "path/to/REQ001.txt")
 
     @patch('doorstop.core.item.Item', MockItem)
     def test_new(self):
@@ -852,7 +847,7 @@ class TestFormatting(unittest.TestCase):
 
     def test_load_save(self):
         """Verify text formatting is preserved."""
-        item = Item(self.ITEM)
+        item = Item(None, self.ITEM)
         item.load()
         item.save()
         text = common.read_text(self.ITEM)
@@ -911,7 +906,7 @@ class TestUnknownItem(unittest.TestCase):
     @patch('doorstop.core.item.log.debug')
     def test_attributes_with_spec(self, mock_warning):
         """Verify all other `Item` attributes raise an exception."""
-        spec = Item(os.path.join(FILES, 'REQ001.yml'))
+        spec = Item(None, os.path.join(FILES, 'REQ001.yml'))
         self.item = UnknownItem(self.item.uid, spec=spec)
         self.assertRaises(AttributeError, getattr, self.item, 'path')
         self.assertRaises(AttributeError, getattr, self.item, 'text')


### PR DESCRIPTION
Make the document a mandatory parameter for Item() object construction.
This emphasizes that items always belong to a document.  This is a
preparation to simplify the implementation of issue #337.