### PR TITLE
Update creation.md to note only one requirement tree per git repo

### DIFF
--- a/docs/cli/creation.md
+++ b/docs/cli/creation.md
@@ -6,6 +6,7 @@ A document can be created inside a directory that is under version control:
 $ doorstop create REQ ./reqs
 created document: REQ (@/reqs)
 ```
+Note: Only one root parent requirements document is allowed per version controlled directory.
 
 Items can be added to the document and edited:
 


### PR DESCRIPTION
Adding clarification because I was trying to add more requirement trees into a single repo and it would not work. 