### PR TITLE
Optionally add extended attr to the fingerprint

### DIFF
--- a/docs/reference/items.md
+++ b/docs/reference/items.md
@@ -88,9 +88,11 @@ e.g. `level: '1.10'`.
 
 ## reviewed
 
-Each item has a fingerprint. The UID of the item, the values of the
+Each item has a fingerprint. By default, the UID of the item, the values of the
 [text](items.md#text) and [ref](items.md#ref) attributes, and the UIDs of the
-[links](items.md#links) attribute contribute to the fingerprint.
+[links](items.md#links) attribute contribute to the fingerprint. Optionally,
+values of extended attributes can be added to the fingerprint through the
+[extended-reviewed](items.md#extended-reviewed-attributes) document setting.
 
 The value of the *reviewed* attribute indicates the fingerprint of the item
 when it was last reviewed. "null" if the item has not yet been reviewed.
@@ -222,10 +224,7 @@ custom attributes (key-value pairs) in the YAML file. The extended attributes
 will not be part of a published document, but they can be queried by a 3rd party
 application through the REST interface or the Python API.
 
-The values of extended attributes do **not** contribute to the
-[fingerprint](items.md#reviewed) of the item.
-
-### Example:
+#### Example: Extended attribute
 
 In this example, an extended attribute `invented-by` is added to the item.
 
@@ -233,6 +232,31 @@ In this example, an extended attribute `invented-by` is added to the item.
 invented-by: some.guy@email.com
 ```
 
+#### Extended reviewed attributes
+
+By default, the values of extended attributes do **not** contribute to the
+[fingerprint](items.md#reviewed) of the item.  Optionally, you can add the
+values of extended attributes to the fingerprint through the
+`extended-reviewed` setting in the corresponding document configuration file
+`.doorstop.yml`.  The `extended-reviewed` setting expects a non-empty list of
+attribute keys.  There is no command to maintain this document setting.  You
+have to edit the document configuration file `.doorstop.yml` by hand.
+
+```yaml
+settings:
+  digits: 3
+  extended-reviewed: [type, verification-method]
+  prefix: REQ
+  sep: ''
+```
+
+If attributes listed in the `extended-reviewed` do not exist in an item of this
+document, then a warning is issued by the validation command `doorstop`:
+
+```
+WARNING: REQ001: missing extended reviewed attribute: type
+WARNING: REQ001: missing extended reviewed attribute: verification-method
+```
 
 # Beta Features
 

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -59,6 +59,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         self._data['sep'] = Document.DEFAULT_SEP
         self._data['digits'] = Document.DEFAULT_DIGITS
         self._data['parent'] = None  # the root document does not have a parent
+        self._data['extended-reviewed'] = []
         self._items = []
         self._itered = False
         self.children = []
@@ -146,6 +147,8 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
                     self._data[key] = value.strip()
                 elif key == 'digits':
                     self._data[key] = int(value)
+                elif key == 'extended-reviewed':
+                    self._data[key] = sorted(set(v for v in value))
                 else:
                     msg = "unexpected document setting '{}' in: {}".format(
                         key, self.config
@@ -174,6 +177,9 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
             elif key == 'digits':
                 sets[key] = value
             elif key == 'parent':
+                if value:
+                    sets[key] = value
+            elif key == 'extended-reviewed':
                 if value:
                     sets[key] = value
             else:
@@ -258,6 +264,12 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         """Set the document's prefix."""
         self._data['prefix'] = Prefix(value)
         # TODO: should the new prefix be applied to all items?
+
+    @property
+    @auto_load
+    def extended_reviewed(self):
+        """Get the document's extended reviewed attribute keys."""
+        return self._data['extended-reviewed']
 
     @property
     @auto_load

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -858,6 +858,13 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         values = [self.uid, self.text, self.ref]
         if links:
             values.extend(self.links)
+        for key in self.document.extended_reviewed:
+            if key in self._data:
+                values.append(self._dump(self._data[key]))
+            else:
+                log.warning(
+                    "{}: missing extended reviewed attribute: {}".format(self.uid, key)
+                )
         return Stamp(*values)
 
     @auto_save

--- a/doorstop/core/tests/__init__.py
+++ b/doorstop/core/tests/__init__.py
@@ -89,6 +89,7 @@ class MockSimpleDocument:
         self.parent = None
         self.prefix = 'RQ'
         self._items = []
+        self.extended_reviewed = []
 
     def __iter__(self):
         yield from self._items

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -48,6 +48,14 @@ settings:
   John: 'Doe'
 """.lstrip()
 
+YAML_EXTENDED_REVIEWED = """
+settings:
+  digits: 3
+  extended-reviewed: [type, verification-method]
+  prefix: REQ
+  sep: ''
+""".lstrip()
+
 
 @patch('doorstop.settings.REORDER', False)
 @patch('doorstop.core.item.Item', MockItem)
@@ -108,6 +116,14 @@ class TestDocument(unittest.TestCase):
         msg = "^unexpected document setting 'John' in: .*\\.doorstop.yml$"
         self.assertRaisesRegex(DoorstopError, msg, self.document.load)
 
+    def test_load_extended_reviewed(self):
+        """Verify loaded extended reviewed attribute keys of a document."""
+        self.document._file = YAML_EXTENDED_REVIEWED
+        self.document.load()
+        self.assertEqual(
+            self.document.extended_reviewed, ['type', 'verification-method']
+        )
+
     def test_save_empty(self):
         """Verify saving calls write."""
         self.document.tree = Mock()
@@ -126,6 +142,20 @@ class TestDocument(unittest.TestCase):
         self.document._data['custom'] = 'this'
         self.document.save()
         self.assertIn("custom: this", self.document._file)
+
+    def test_save_extended_reviewed(self):
+        """Verify saving of extended reviewed attribute keys."""
+        self.document._data['extended-reviewed'] = ['type', 'verification-method']
+        self.document.save()
+        self.assertIn("extended-reviewed:", self.document._file)
+        self.assertIn("- type", self.document._file)
+        self.assertIn("- verification-method", self.document._file)
+
+    def test_no_save_empty_extended_reviewed(self):
+        """Verify not saving of empty extended reviewed attribute keys."""
+        self.document._data['extended-reviewed'] = []
+        self.document.save()
+        self.assertNotIn("extended-reviewed:", self.document._file)
 
     @patch('doorstop.common.verbosity', 2)
     def test_str(self):
@@ -184,6 +214,7 @@ class TestDocument(unittest.TestCase):
         document = MockDocument.new(None, EMPTY, root=FILES, prefix='NEW', digits=2)
         self.assertEqual('NEW', document.prefix)
         self.assertEqual(2, document.digits)
+        self.assertEqual([], document.extended_reviewed)
         MockDocument._create.assert_called_once_with(path, name='document')
 
     def test_new_existing(self):

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -809,6 +809,45 @@ class TestItem(unittest.TestCase):
         stamp = 'c6a87755b8756b61731c704c6a7be4a2'
         self.assertEqual(stamp, self.item.stamp())
 
+    def test_stamp_with_one_extended_reviewed(self):
+        """Verify fingerprint with one extended reviewed attribute."""
+        self.item._data['type'] = 'functional'
+        self.item.document.extended_reviewed = ['type']
+        stamp = '04fdd093f67ce3a3160dfdc5d93e7813'
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_two_extended_reviewed(self):
+        """Verify fingerprint with two extended reviewed attributes."""
+        self.item._data['type'] = 'functional'
+        self.item._data['verification-method'] = 'test'
+        self.item.document.extended_reviewed = ['type', 'verification-method']
+        stamp = 'cf8aaea03cd5765bac978ad74a42d729'
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_reversed_extended_reviewed_reverse(self):
+        """Verify fingerprint with reversed extended reviewed attributes."""
+        self.item._data['type'] = 'functional'
+        self.item._data['verification-method'] = 'test'
+        self.item.document.extended_reviewed = ['verification-method', 'type']
+        stamp = '7b14dfcc17026e98790284c5cddb0900'
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_missing_extended_reviewed_reverse(self):
+        """Verify fingerprint with missing extended reviewed attribute."""
+        with ListLogHandler(core.item.log) as handler:
+            self.item._data['type'] = 'functional'
+            self.item._data['verification-method'] = 'test'
+            self.item.document.extended_reviewed = [
+                'missing',
+                'type',
+                'verification-method',
+            ]
+            stamp = 'cf8aaea03cd5765bac978ad74a42d729'
+            self.assertEqual(stamp, self.item.stamp())
+            self.assertIn(
+                "RQ001: missing extended reviewed attribute: missing", handler.records
+            )
+
     def test_stamp_links(self):
         """Verify an item's contents can be stamped."""
         self.item.link('mock_link')


### PR DESCRIPTION
Add a document configuration option (via .doorstop.yml) to specify a
list of attributes those values will be included in the item
fingerprint.

Close #337.